### PR TITLE
Print keys and values on the same line in dict-like objects

### DIFF
--- a/private/association-list.rkt
+++ b/private/association-list.rkt
@@ -34,6 +34,7 @@
          rebellion/collection/immutable-vector
          rebellion/collection/keyset
          rebellion/collection/multiset
+         rebellion/private/spliced-printing-entry
          rebellion/type/record)
 
 (module+ test
@@ -70,9 +71,8 @@
      (λ (this)
        (define backing-hash (accessor this backing-hash-field))
        (for*/list ([(k vs) (in-immutable-hash backing-hash)]
-                   [v (in-vector vs)]
-                   [k-or-v (in-list (list k v))])
-         k-or-v))))
+                   [v (in-vector vs)])
+         (spliced-printing-entry k v)))))
   (list (cons prop:equal+hash equal+hash)
         (cons prop:custom-write custom-write)))
 

--- a/private/multidict.rkt
+++ b/private/multidict.rkt
@@ -38,6 +38,7 @@
          rebellion/collection/entry
          rebellion/collection/multiset
          rebellion/collection/keyset
+         rebellion/private/spliced-printing-entry
          rebellion/streaming/reducer
          rebellion/type/record)
 
@@ -69,9 +70,8 @@
     (make-constructor-style-printer
      (λ (_) type-name)
      (λ (this)
-       (for*/list ([e (sequence this)]
-                   [k-or-v (in-list (list (entry-key e) (entry-value e)))])
-         k-or-v))))
+       (for*/list ([e (sequence this)])
+         (spliced-printing-entry (entry-key e) (entry-value e))))))
   (define (sequence this)
     (define backing-hash (accessor this backing-hash-field))
     (for*/stream ([(k vs) (in-immutable-hash backing-hash)]

--- a/private/record-type.rkt
+++ b/private/record-type.rkt
@@ -40,6 +40,7 @@
          rebellion/collection/keyset/low-dependency
          rebellion/custom-write
          rebellion/equal+hash
+         rebellion/private/spliced-printing-entry
          rebellion/type/tuple
          syntax/parse/define)
 
@@ -157,10 +158,10 @@
    (λ (_) type-name)
    (λ (this)
      (for*/list ([i (in-range size)]
-                 [kw (in-value (keyset-ref fields i))]
-                 [item (in-list (list (unquoted-printing-keyword kw)
-                                      (accessor this i)))])
-       item))))
+                 [kw (in-value (keyset-ref fields i))])
+       (define v (accessor this i))
+       (define kw-str (unquoted-printing-keyword kw))
+       (spliced-printing-entry kw-str v)))))
 
 (define (make-record-field-accessor descriptor field)
   (define accessor (record-descriptor-accessor descriptor))

--- a/private/record.rkt
+++ b/private/record.rkt
@@ -29,6 +29,7 @@
          rebellion/base/generative-token
          rebellion/collection/immutable-vector
          rebellion/collection/keyset
+         rebellion/private/spliced-printing-entry
          rebellion/type/record
          rebellion/type/tuple)
 
@@ -48,12 +49,9 @@
         (define keywords (accessor this 0))
         (define values (accessor this 1))
         (for/list ([kw (in-list (keyset->list keywords))]
-                   [v (in-vector values)]
-                   #:when #t
-                   [kw-or-v
-                    (in-list (list (unquoted-printing-string (format "~s" kw))
-                                   v))])
-          kw-or-v))))
+                   [v (in-vector values)])
+          (define kw-str (unquoted-printing-string (format "~s" kw)))
+          (spliced-printing-entry kw-str v)))))
   (list (cons prop:equal+hash (make-tuple-equal+hash descriptor))
         (cons prop:custom-write custom-write)))
 

--- a/private/spliced-printing-entry.rkt
+++ b/private/spliced-printing-entry.rkt
@@ -1,0 +1,36 @@
+#lang racket/base
+
+(require racket/contract/base)
+
+(provide
+ (contract-out
+  [spliced-printing-entry (-> any/c any/c spliced-printing-entry?)]
+  [spliced-printing-entry? any/c]))
+
+(module+ test
+  (require (submod "..")
+           racket/pretty
+           rackunit))
+
+;@------------------------------------------------------------------------------
+
+(struct spliced-printing-entry (key value)
+  #:transparent
+  #:methods gen:custom-write
+  [(define (write-proc this out mode)
+     (define (recur x)
+       (case mode
+         ((#t) (write x out))
+         ((#f) (display x out))
+         ((0 1) (print x out mode))))
+     (recur (spliced-printing-entry-key this))
+     (write-string " " out)
+     (recur (spliced-printing-entry-value this)))])
+
+(module+ test
+  (test-case "spliced-printing-entry"
+    (define v
+      (list (spliced-printing-entry 'foo 1)
+            (spliced-printing-entry 'bar 2)
+            (spliced-printing-entry 'baz 3)))
+    (check-equal? (pretty-format v 10) "'(foo 1\n  bar 2\n  baz 3)")))


### PR DESCRIPTION
Closes #39. Also makes various documentation examples print much more readable output.