### PR TITLE
Demonstrate converting a few files to use Parendown

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -10,10 +10,13 @@
 
 (define deps
   (list "base"
+        "lathe-comforts-lib"
         "reprovide-lang"))
 
 (define build-deps
-  (list "net-doc"
+  (list "lathe-comforts-doc"
+        "net-doc"
+        "parendown-lib"
         "racket-doc"
         "rackunit-lib"
         "scribble-lib"))

--- a/private/list.rkt
+++ b/private/list.rkt
@@ -1,9 +1,8 @@
-#lang racket/base
+#lang parendown racket/base
 
 (require racket/contract/base)
 
-(provide
- (contract-out
+(provide #/contract-out
   [empty-list empty-list?]
   [empty-list? predicate/c]
   [nonempty-list? predicate/c]
@@ -17,9 +16,12 @@
   [list-reverse (-> list? list?)]
   [into-list reducer?]
   [into-reversed-list reducer?]
-  [appending-into-list reducer?]))
+  [appending-into-list reducer?])
 
 (require racket/math
+         (only-in lathe-comforts expect fn w-loop)
+         (only-in lathe-comforts/list nat->maybe)
+         (only-in lathe-comforts/maybe just)
          rebellion/base/option
          rebellion/streaming/reducer)
 
@@ -31,7 +33,7 @@
 
 (define empty-list (list))
 (define (empty-list? v) (and (list? v) (equal? v empty-list)))
-(define (nonempty-list? v) (and (list? v) (not (equal? v empty-list))))
+(define (nonempty-list? v) (and (list? v) (not #/equal? v empty-list)))
 
 (define (list-size lst) (length lst))
 (define (list-insert lst v) (cons v lst))
@@ -39,18 +41,17 @@
 (define (list-rest lst) (cdr lst))
 (define (list-append . lsts) (apply append lsts))
 (define (list-reverse lst) (reverse lst))
-(define (list-contains? lst v) (not (not (member v lst))))
+(define (list-contains? lst v) (not #/not #/member v lst))
 
 (define (list-ref-safe lst pos)
-  (let loop ([lst lst] [pos pos])
-    (cond
-      [(empty-list? lst) absent]
-      [(zero? pos) (present (list-first lst))]
-      [else (loop (list-rest lst) (sub1 pos))])))
+  (w-loop loop lst lst pos pos
+    (expect lst (cons elem lst) absent
+    #/expect (nat->maybe pos) (just pos) (present elem)
+    #/loop lst pos)))
 
 (define into-list
   (make-effectful-fold-reducer list-insert
-                               (λ () empty-list)
+                               (fn empty-list)
                                list-reverse
                                #:name 'into-list))
 
@@ -58,7 +59,7 @@
   (make-fold-reducer list-insert empty-list #:name 'into-reversed-list))
 
 (define appending-into-list
-  (reducer-map into-list #:range (λ (lst) (apply list-append lst))))
+  (reducer-map into-list #:range #/fn lst #/apply list-append lst))
 
 (module+ test
   (test-case "list-ref-safe"
@@ -67,17 +68,17 @@
     (check-equal? (list-ref-safe lst 2) (present 'c))
     (check-equal? (list-ref-safe lst 3) absent))
   (test-case "list-contains?"
-    (check-true (list-contains? (list 1 2 3) 1))
-    (check-true (list-contains? (list 1 2 3) 2))
-    (check-true (list-contains? (list 1 2 3) 3))
-    (check-false (list-contains? (list 1 2 3) 4)))
+    (check-true #/list-contains? (list 1 2 3) 1)
+    (check-true #/list-contains? (list 1 2 3) 2)
+    (check-true #/list-contains? (list 1 2 3) 3)
+    (check-false #/list-contains? (list 1 2 3) 4))
   (test-case "empty-lists"
     (check-pred empty-list? empty-list)
     (check-pred empty-list? (list))
     (check-pred nonempty-list? (list 1 2 3))
-    (check-false (empty-list? (list 1 2 3)))
-    (check-false (nonempty-list? empty-list))
-    (check-false (nonempty-list? (list))))
+    (check-false #/empty-list? #/list 1 2 3)
+    (check-false #/nonempty-list? empty-list)
+    (check-false #/nonempty-list? #/list))
   (test-case "into-list"
     (check-equal? (reduce into-list 1 2 3 4 5) (list 1 2 3 4 5))
     (check-equal? (reduce into-list) empty-list))

--- a/private/record.scrbl
+++ b/private/record.scrbl
@@ -3,6 +3,7 @@
 @(require (for-label racket/base
                      racket/contract/base
                      racket/math
+                     (only-in lathe-comforts/maybe just maybe? nothing)
                      rebellion/collection/keyset
                      rebellion/collection/record)
           (submod rebellion/private/scribble-evaluator-factory doc)
@@ -78,6 +79,19 @@ hash table whose keys are symbols or strings, use records instead.
              #:age 42
              #:favorite-color 'turqoise))
    (record-size rec))}
+
+@defproc[(record-ref-maybe [rec record?] [kw keyword?]) maybe?]{
+ Returns a @racket{just} of the value in @racket[rec] for @racket[kw], or
+ @racket[(nothing)] if none exists.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (define rec
+     (record #:name "Alyssa P. Hacker"
+             #:age 42
+             #:favorite-color 'turqoise))
+   (record-ref-maybe rec '#:name)
+   (record-ref-maybe rec '#:fur-color)))}
 
 @defproc[(record-ref [rec record?] [kw keyword?]) any/c]{
  Returns the value in @racket[rec] for @racket[kw], or @racket[#f] if none


### PR DESCRIPTION
**Please don't actually merge this commit.** I doubt Parendown works well with DrRacket and the other tools and expectations of the Racket community, so I expect this kind of change to *inhibit* future maintenance of Rebellion. (In practice, I use Parendown only in codebases for which I anticipate maintaining a Cene port, since it makes Racket resemble Cene.)

Even if you don't consider that to be a problem, I haven't even refactored the whole codebase, just a few files.

The reason I'm putting this pull request out there is because you were mentioning it might be a good way to discuss Parendown in the context of an actual codebase.

The place Parendown is most essential, continuation-passing style (or monadic style), isn't much of a factor in the Rebellion codebase. It's also pretty rare for Rebellion to have cascades of early-exit branches since it does its error-checking using Racket contracts instead. As a result, if you look through the changes, you'll notice a lot of them are rather insignificant (mainly of stylistic value, if anything), and even the more significant ones aren't game-changers.

Some of the most significant changes come from places that use `cond` and struct accessors in Rebellion. These turn into rather more concise pattern-matching branches in the (Parendown + Lathe Comforts) style, and these cascades of branches give Parendown a chance to shine.

Anyway, whenever we get to talking about Parendown again, I hope this achieves the goal of providing us with some tangible examples. :)