### PR TITLE
Add experimental stream signals API

### DIFF
--- a/private/stream-signal.rkt
+++ b/private/stream-signal.rkt
@@ -1,0 +1,104 @@
+#lang racket/base
+
+(require racket/contract/base)
+
+(provide
+ (contract-out
+  [signal-output (-> #:state any/c #:on? boolean? signal-output?)]
+  [signal-output? predicate/c]
+  [signal-output-state (-> signal-output? any/c)]
+  [signal-output-on? (-> signal-output? boolean?)]
+  [stream-signal? predicate/c]
+  [make-fold-stream-signal
+   (->* ((-> any/c any/c signal-output?) signal-output?)
+        (#:name (or/c interned-symbol? #f))
+        stream-signal?)]
+  [filtering-on (-> stream-signal? transducer?)]
+  [taking-while-on (-> stream-signal? transducer?)]
+  [dropping-while-on (-> stream-signal? transducer?)]
+  [increasing? (-> (-> any/c any/c (or/c '< '= '>)) stream-signal?)]))
+
+(require racket/contract/region
+         rebellion/base/option
+         rebellion/base/pair
+         rebellion/base/symbol
+         rebellion/base/variant
+         rebellion/collection/list
+         rebellion/streaming/transducer
+         rebellion/type/record
+         rebellion/type/reference)
+
+;@------------------------------------------------------------------------------
+
+(define/contract (impossible _)
+  (-> none/c any/c)
+  #f)
+
+(define-record-type signal-output (state on?))
+
+(define-reference-type stream-signal (starter consumer finisher))
+
+(define (make-fold-stream-signal f init-output #:name [name #f])
+  (make-stream-signal #:starter (λ () init-output)
+                      #:consumer f
+                      #:finisher void
+                      #:name name))
+
+(define-record-type signalling-state (value on? consumed))
+
+(define (signalling signal)
+  (define starter (stream-signal-starter signal))
+  (define consumer (stream-signal-consumer signal))
+  (define finisher (stream-signal-finisher signal))
+  (make-transducer
+   #:starter (λ () (variant #:consume (signal-output-state (starter))))
+   #:consumer (λ (state v)
+               (define output (consumer state v))
+               (define next-state
+                 (signalling-state #:value (signal-output-state output)
+                                   #:on? (signal-output-on? output)
+                                   #:consumed v))
+               (variant #:emit next-state))
+   #:emitter (λ (state)
+               (emission (variant #:consume (signalling-state-value state))
+                         (pair (signalling-state-consumed state)
+                               (signalling-state-on? state))))
+   #:half-closer (λ (_) (variant #:finish #f))
+   #:half-closed-emitter impossible
+   #:finisher void
+   #:name 'signalling))
+
+(define (filtering-on signal)
+  (transducer-pipe (signalling signal)
+                   (filtering pair-second)
+                   (mapping pair-first)))
+
+(define (taking-while-on signal)
+  (transducer-pipe (signalling signal)
+                   (taking-while pair-second)
+                   (mapping pair-first)))
+
+(define (dropping-while-on signal)
+  (transducer-pipe (signalling signal)
+                   (dropping-while pair-second)
+                   (mapping pair-first)))
+
+(define (increasing? cmp)
+  (make-fold-stream-signal
+   (λ (state v)
+     (define on?
+       (option-case state
+                    #:present (λ (previous)
+                                (not (equal? (cmp previous v) '>)))
+                    #:absent (λ () #t)))
+     (signal-output #:state (present v)
+                    #:on? on?))
+   (signal-output #:state absent #:on? #t)
+   #:name 'increasing?))
+
+(define (real<=> x y)
+  (cond [(< x y) '<] [(= x y) '=] [else '>]))
+
+(transduce (list 0 1 2 3 4 5 2 0 1 2 7 8 9)
+           (signalling (increasing? real<=>))
+           #:into into-list)

--- a/private/stream-signal.scrbl
+++ b/private/stream-signal.scrbl
@@ -1,0 +1,62 @@
+#lang scribble/manual
+
+@title{Stream Signals}
+@defmodule[rebellion/streaming/signal]
+
+A @deftech{stream signal} or simply @deftech{signal} is an object that describes
+a boolean-valued property over a sequence of values. Once started, a signal is
+either @deftech{on} or @deftech{off} and may toggle between these states when
+receiving the elements of a sequence. Stream signals may be thought of as
+predicates that have state, which may be updated in between sequence elements.
+
+@defproc[(stream-signal? [v any/c]) boolean?]{
+ A predicate for @tech{stream signals}.}
+
+@section{Basic Signals}
+
+@defproc[(increasing? [cmp (-> any/c any/c (or/c '< '= '>))]
+                      [#:strictly? strictly? boolean? #f])
+         stream-signal?]{
+ A @tech{stream signal} that is @tech{on} when @racket[cmp] indicates that the
+ current sequence element is not smaller than the previous element. If @racket[
+ strictly?] is @racket[#t], elements must be greater than their predecessor for
+ the signal to be on --- an element that is equal to its predecessor would turn
+ the signal off.}
+
+@defproc[(decreasing? [cmp (-> any/c any/c (or/c '< '= '>))]
+                      [#:strictly? strictly? boolean? #f])
+         stream-signal?]{
+ Like @racket[increasing?], but the constructed @tech{signal} is @tech{on} when
+ elements are decreasing, not increasing.}
+
+@section{Using Signals in Sequence Transformations}
+
+@defproc[(filtering-on [signal stream-signal?]) transducer?]{
+ Constructs a @tech{transducer} that emits elements only when @racket[signal] is
+ @tech{on}.}
+
+@defproc[(taking-while-on [signal stream-signal?]) transducer?]{
+ Constructs a @tech{transducer} that emits upstream elements as long as @racket[
+ signal] is @tech{on}, terminating the sequence as soon as it's @tech{off}.}
+
+@defproc[(dropping-while-on [signal stream-signal?]) transducer?]{
+ Constructs a @tech{transducer} that drops upstream elements as long as @racket[
+ signal] is @tech{on}. Once it's @tech{off}, upstream elements are emitted
+ normally until the sequence ends, even if @racket[signal] turns back
+ @tech{on}.}
+
+@section{Constructing Signals}
+
+@defproc[(make-fold-stream-signal [f (-> any/c any/c signal-output?)]
+                                  [init any/c]
+                                  [#:name name (or/c interned-symbol? #f)])
+         signal?]
+
+@defproc[(signal-output? [v any/c]) boolean?]
+
+@defproc[(signal-output [#:state state any/c]
+                        [#:on? on? boolean?]) signal-output?]
+
+@defproc[(signal-output-state [output signal-output?]) any/c]
+
+@defproc[(signal-output-on? [output signal-output?]) boolean?]

--- a/streaming/signal.rkt
+++ b/streaming/signal.rkt
@@ -1,0 +1,2 @@
+#lang reprovide
+rebellion/private/stream-signal


### PR DESCRIPTION
This PR adds _stream signals_, which are sort of halfway between folds and predicates. They can be used with transducers and reducers to express stream operations like "stop processing this stream of items once their total weight is greater than 100".

Not yet finished, and I might never get around to finishing it. I'm opening this pull request mostly as a way to document what I did and make it easier to find and refer to in the future.