### PR TITLE
More multiset changes

### DIFF
--- a/private/multiset.rkt
+++ b/private/multiset.rkt
@@ -52,7 +52,6 @@
 
 (define (make-multiset-props descriptor)
   (define name (record-type-name (record-descriptor-type descriptor)))
-  (define accessor (record-descriptor-accessor descriptor))
   (define equal+hash (make-record-equal+hash descriptor))
   (define custom-write
     (make-constructor-style-printer

--- a/private/multiset.rkt
+++ b/private/multiset.rkt
@@ -199,10 +199,11 @@
       (check-equal? (multiset-remove set 'd #:copies +inf.0) set))))
 
 (define (multiset-union a b)
-  (constructor:multiset (+ (multiset-size a) (multiset-size b))
-                        (hash-union (multiset-frequencies a)
-                                    (multiset-frequencies b)
-                                    #:combine +)))
+  (constructor:multiset
+   #:size (+ (multiset-size a) (multiset-size b))
+   #:frequencies (hash-union (multiset-frequencies a)
+                             (multiset-frequencies b)
+                             #:combine +)))
 
 (define (multiset-add-all set seq)
   (multiset-union set

--- a/private/multiset.scrbl
+++ b/private/multiset.scrbl
@@ -33,6 +33,9 @@ can contain duplicate elements. Elements are always compared with @racket[
    (multiset 'apple 'orange 'orange 'banana)
    (multiset))}
 
+@defthing[empty-multiset multiset? #:value (multiset)]{
+ The empty @tech{multiset}, which contains no elements.}
+
 @section{Querying Multisets}
 
 @defproc[(multiset-size [set multiset?]) natural?]{
@@ -90,24 +93,39 @@ performance characteristics of these operations are not specified at this time,
 but their running times are all sublinear in the number of distinct elements in
 the modified multiset.
 
-@defproc[(multiset-add [set multiset?] [element any/c]) multiset?]{
- Adds @racket[element] to @racket[set], returning an updated @tech{multiset}.
+@defproc[(multiset-add [set multiset?]
+                       [element any/c]
+                       [#:copies num-copies natural? 1])
+         multiset?]{
+ Adds @racket[element] to @racket[set], returning an updated @tech{multiset}. If
+ @racket[copies] is specified, then @racket[element] is added @racket[
+ num-copies] times instead of only once.
 
  @(examples
    #:eval (make-evaluator) #:once
    (multiset-add (multiset 'apple 'orange 'banana) 'grape)
-   (multiset-add (multiset 'apple 'orange 'banana) 'orange))}
+   (multiset-add (multiset 'apple 'orange 'banana) 'orange)
+   (multiset-add (multiset 'apple 'orange 'banana) 'orange #:copies 5))}
 
-@defproc[(multiset-remove-once [set multiset?] [element any/c]) multiset?]{
+@defproc[(multiset-remove [set multiset?]
+                          [element any/c]
+                          [#:copies num-copies (or/c natural? +inf.0) 1])
+         multiset?]{
  Removes a single @racket[element] from @racket[set], returning an updated
- @tech{multiset}. If @racket[set] does not contain @racket[element] then it is
- returned unchanged.
+ @tech{multiset}. If @racket[num-copies] is specified then instead that many
+ copies of @racket[element] are removed from @racket[set], removing all
+ occurrences if @racket[num-copies] is @racket[+inf.0] or if @racket[set]
+ contains fewer occurrences of @racket[element] than @racket[num-copies].
 
  @(examples
    #:eval (make-evaluator) #:once
-   (multiset-remove-once (multiset 'apple 'orange 'banana) 'grape)
-   (multiset-remove-once (multiset 'apple 'orange 'banana) 'orange)
-   (multiset-remove-once (multiset 'apple 'apple 'orange 'banana) 'apple))}
+   (eval:no-prompt
+    (define set (multiset 'blue 'blue 'red 'red 'red 'green)))
+   (multiset-remove set 'red)
+   (multiset-remove set 'red #:copies 2)
+   (multiset-remove set 'red #:copies 5)
+   (multiset-remove set 'blue #:copies +inf.0)
+   (multiset-remove set 'orange))}
 
 @defproc[(multiset-set-frequency [set multiset?]
                                  [element any/c]
@@ -179,6 +197,3 @@ the modified multiset.
  @(examples
    #:eval (make-evaluator) #:once
    (list->multiset (list 'a 'a 'b 'c 'c 'c 'd)))}
-
-@defthing[empty-multiset multiset? #:value (multiset)]{
- The empty @tech{multiset}, which contains no elements.}

--- a/private/multiset.scrbl
+++ b/private/multiset.scrbl
@@ -90,24 +90,38 @@ performance characteristics of these operations are not specified at this time,
 but their running times are all sublinear in the number of distinct elements in
 the modified multiset.
 
-@defproc[(multiset-add [set multiset?] [v any/c]) multiset?]{
- Adds @racket[v] to @racket[set], returning an updated @tech{multiset}. The
- original @racket[set] is not mutated.
+@defproc[(multiset-add [set multiset?] [element any/c]) multiset?]{
+ Adds @racket[element] to @racket[set], returning an updated @tech{multiset}.
 
  @(examples
    #:eval (make-evaluator) #:once
    (multiset-add (multiset 'apple 'orange 'banana) 'grape)
    (multiset-add (multiset 'apple 'orange 'banana) 'orange))}
 
-@defproc[(multiset-remove-once [set multiset?] [v any/c]) multiset?]{
- Removes a single @racket[v] from @racket[set], returning an updated
- @tech{multiset}. The original @racket[set] is not mutated.
+@defproc[(multiset-remove-once [set multiset?] [element any/c]) multiset?]{
+ Removes a single @racket[element] from @racket[set], returning an updated
+ @tech{multiset}. If @racket[set] does not contain @racket[element] then it is
+ returned unchanged.
 
  @(examples
    #:eval (make-evaluator) #:once
    (multiset-remove-once (multiset 'apple 'orange 'banana) 'grape)
    (multiset-remove-once (multiset 'apple 'orange 'banana) 'orange)
    (multiset-remove-once (multiset 'apple 'apple 'orange 'banana) 'apple))}
+
+@defproc[(multiset-set-frequency [set multiset?]
+                                 [element any/c]
+                                 [frequency natural?])
+         multiset?]{
+ Adds or removes copies of @racket[element] to or from @racket[set] until it
+ occurs exactly @racket[frequency] times in @racket[set]. If @racket[frequency]
+ is zero, this is equivalent to removing all copies of @racket[element] from
+ @racket[set].
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (multiset-set-frequency (multiset 'red 'red 'blue 'green) 'blue 4)
+   (multiset-set-frequency (multiset 'red 'red 'blue 'green) 'blue 0))}
 
 @section{Multiset Iteration and Comprehension}
 

--- a/private/multiset.scrbl
+++ b/private/multiset.scrbl
@@ -33,6 +33,8 @@ can contain duplicate elements. Elements are always compared with @racket[
    (multiset 'apple 'orange 'orange 'banana)
    (multiset))}
 
+@section{Querying Multisets}
+
 @defproc[(multiset-size [set multiset?]) natural?]{
  Returns the total number of elements in @racket[set], including duplicates.
 
@@ -40,35 +42,6 @@ can contain duplicate elements. Elements are always compared with @racket[
    #:eval (make-evaluator) #:once
    (define set (multiset 5 8 8 8))
    (multiset-size set))}
-
-@defproc[(multiset-add [set multiset?] [v any/c]) multiset?]{
- Adds @racket[v] to @racket[set], returning an updated @tech{multiset}. The
- original @racket[set] is not mutated.
-
- @(examples
-   #:eval (make-evaluator) #:once
-   (multiset-add (multiset 'apple 'orange 'banana) 'grape)
-   (multiset-add (multiset 'apple 'orange 'banana) 'orange))}
-
-@defproc[(multiset-remove-once [set multiset?] [v any/c]) multiset?]{
- Removes a single @racket[v] from @racket[set], returning an updated
- @tech{multiset}. The original @racket[set] is not mutated.
-
- @(examples
-   #:eval (make-evaluator) #:once
-   (multiset-remove-once (multiset 'apple 'orange 'banana) 'grape)
-   (multiset-remove-once (multiset 'apple 'orange 'banana) 'orange)
-   (multiset-remove-once (multiset 'apple 'apple 'orange 'banana) 'apple))}
-
-@defproc[(multiset-contains? [set multiset?] [v any/c]) boolean?]{
- Returns @racket[#t] if @racket[set] contains @racket[v], @racket[#f] otherwise.
-
- @(examples
-   #:eval (make-evaluator) #:once
-   (define set (multiset 'apple 'orange 'orange))
-   (multiset-contains? set 'apple)
-   (multiset-contains? set 'orange)
-   (multiset-contains? set 42))}
 
 @defproc[(multiset-frequency [set multiset?] [v any/c]) natural?]{
  Returns the number of times that @racket[set] contains @racket[v].
@@ -90,12 +63,51 @@ can contain duplicate elements. Elements are always compared with @racket[
    (multiset-frequencies
     (multiset 'red 'red 'red 'blue 'green 'green 'green 'green)))}
 
+@defproc[(multiset-contains? [set multiset?] [v any/c]) boolean?]{
+ Returns @racket[#t] if @racket[set] contains @racket[v], @racket[#f] otherwise.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (define set (multiset 'apple 'orange 'orange))
+   (multiset-contains? set 'apple)
+   (multiset-contains? set 'orange)
+   (multiset-contains? set 42))}
+
 @defproc[(multiset-unique-elements [set multiset?]) immutable-set?]{
  Removes all duplicate elements from @racket[set], returning the resulting set.
 
  @(examples
    #:eval (make-evaluator) #:once
    (multiset-unique-elements (multiset 5 8 8 8 13 13)))}
+
+@section{Persistently Updating Multisets}
+
+Multisets are always immutable. The following update operations return new
+multisets and leave the input multiset unchanged. However, multisets are
+implemented with an efficient persistent data structure that allows the modified
+multisets to share their structure with the input multiset. The precise
+performance characteristics of these operations are not specified at this time,
+but their running times are all sublinear in the number of distinct elements in
+the modified multiset.
+
+@defproc[(multiset-add [set multiset?] [v any/c]) multiset?]{
+ Adds @racket[v] to @racket[set], returning an updated @tech{multiset}. The
+ original @racket[set] is not mutated.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (multiset-add (multiset 'apple 'orange 'banana) 'grape)
+   (multiset-add (multiset 'apple 'orange 'banana) 'orange))}
+
+@defproc[(multiset-remove-once [set multiset?] [v any/c]) multiset?]{
+ Removes a single @racket[v] from @racket[set], returning an updated
+ @tech{multiset}. The original @racket[set] is not mutated.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (multiset-remove-once (multiset 'apple 'orange 'banana) 'grape)
+   (multiset-remove-once (multiset 'apple 'orange 'banana) 'orange)
+   (multiset-remove-once (multiset 'apple 'apple 'orange 'banana) 'apple))}
 
 @section{Multiset Iteration and Comprehension}
 


### PR DESCRIPTION
Closes #243.

This pull request goes back on the decision in #241 to have separate `multiset-remove-once` and `multiset-remove-every` functions and instead changes the API to a single `multiset-remove` function with an optional `#:copies` keyword argument. The `multiset-add` function is similarly extended with a `#:copies` keyword argument. The argument defaults to 1 and indicates how many times the element should be added or removed from the multiset. In the case of removal, the `#:copies` argument can be `+inf.0` to indicate that all copies of the element should be removed, regardless of how many there are in the multiset.

Additionally, a `multiset-set-frequency` function is provided for directly changing the number of occurrences of an element in the multiset. Both multiset addition and removal are implemented in terms of this function.

This is technically a breaking change, but Rebellion has only three transitive clients in the package catalog and the `multiset-remove-once` function has only existed for less than a day, so I'm fine with that.

This obsoletes #246 and probably conflicts with #247, so I'll wait to merge this until after #247 is merged.