### PR TITLE
Remove list->multiset

### DIFF
--- a/private/association-list.rkt
+++ b/private/association-list.rkt
@@ -97,10 +97,9 @@
   (hash-ref (association-list-backing-hash assoc) k empty-immutable-vector))
 
 (define (association-list-keys assoc)
-  (list->multiset
-    (for*/list ([(k vec) (in-hash (association-list-backing-hash assoc))]
-                [_ (in-range (immutable-vector-length vec))])
-      k)))
+  (for*/multiset ([(k vec) (in-hash (association-list-backing-hash assoc))]
+                  [_ (in-range (immutable-vector-length vec))])
+    k))
 
 (define (association-list-unique-keys assoc)
   (multiset-unique-elements (association-list-keys assoc)))

--- a/private/multiset.rkt
+++ b/private/multiset.rkt
@@ -21,7 +21,6 @@
   [multiset-size (-> multiset? natural?)]
   [multiset-unique-elements (-> multiset? immutable-set?)]
   [multiset->list (-> multiset? list?)]
-  [list->multiset (-> list? multiset?)]
   [sequence->multiset (-> (sequence/c any/c) multiset?)]
   [empty-multiset multiset?]
   [in-multiset (-> multiset? sequence?)]
@@ -223,8 +222,6 @@
 (define (multiset->list set)
   (frequency-hash->list (multiset-frequencies set)))
 
-(define (list->multiset lst) (apply multiset lst))
-
 (define (sequence->multiset seq)
   (reduce-all into-multiset seq))
 
@@ -251,8 +248,6 @@
     (check-true (multiset-contains? letters 'b))
     (check-false (multiset-contains? letters 'foo)))
   (test-case "conversion"
-    (check-equal? (list->multiset (multiset->list letters)) letters)
-    (check-equal? (length (multiset->list letters)) 7)
     (check-equal? (sequence->multiset "hello")
                   (multiset #\h #\e #\l #\l #\o)))
   (test-case "iteration"

--- a/private/multiset.scrbl
+++ b/private/multiset.scrbl
@@ -200,14 +200,6 @@ the modified multiset.
    #:eval (make-evaluator) #:once
    (multiset->list (multiset 'a 'a 'b 'c 'c 'c 'd)))}
 
-@defproc[(list->multiset [lst list?]) multiset?]{
- Returns a @tech{multiset} containing the elements of @racket[lst], including
- duplicates.
-
- @(examples
-   #:eval (make-evaluator) #:once
-   (list->multiset (list 'a 'a 'b 'c 'c 'c 'd)))}
-
 @defproc[(sequence->multiset [seq sequence?]) multiset?]{
  Returns a @tech{multiset} containing the elements of @racket[seq], including
  duplicates.


### PR DESCRIPTION
This PR addresses #252.

The first commit replaces all calls to `list->multiset` with `sequence->multiset`, the second commit removes the definition, tests, and docs for `list->multiset`.

This is my first Racket-related PR so I welcome any feedback.

Let me know if there are any other code or doc changes needed (eg: notice about breaking backwards-compatibility etc...)