### PR TITLE
Fix renames

### DIFF
--- a/private/association-list.rkt
+++ b/private/association-list.rkt
@@ -150,16 +150,16 @@
     (check-equal? (association-list-ref assoc 'd) empty-immutable-vector)
     (check-not-equal? (association-list-ref assoc 'a)
                       (association-list-ref alt-assoc 'a)))
-  
+
   (test-case "association-list-size"
     (check-equal? (association-list-size assoc) 4))
-  
+
   (test-case "association-list-keys"
     (check-equal? (association-list-keys assoc) (multiset 'a 'a 'b 'c)))
-  
+
   (test-case "association-list-unique-keys"
     (check-equal? (association-list-unique-keys assoc) (set 'a 'b 'c)))
-  
+
   (test-case "association-list-values"
     (define vs (association-list-values assoc))
     (check-equal? (immutable-vector-length vs) 4)
@@ -170,7 +170,7 @@
     (check-true (< (immutable-vector-index-of vs 1)
                    (immutable-vector-index-of vs 3)))
     (check-not-equal? vs (association-list-values alt-assoc)))
-  
+
   (test-case "association-list-entries"
     (define entries (association-list-entries assoc))
     (check-equal? (immutable-vector-length entries) 4)
@@ -181,7 +181,7 @@
     (check-true (< (immutable-vector-index-of entries (entry 'a 1))
                    (immutable-vector-index-of entries (entry 'a 3))))
     (check-not-equal? entries (association-list-entries alt-assoc)))
-  
+
   (test-case "association-list->hash"
     (check-equal? (association-list->hash assoc)
                   (hash 'a (immutable-vector 1 3)

--- a/private/association-list.rkt
+++ b/private/association-list.rkt
@@ -64,7 +64,7 @@
   (define accessor (record-descriptor-accessor descriptor))
   (define backing-hash-field
     (keyset-index-of (record-type-fields type) '#:backing-hash))
-  (define equal+hash (make-record-equal+hash descriptor))
+  (define equal+hash (default-record-equal+hash descriptor))
   (define custom-write
     (make-constructor-style-printer
      (λ (_) type-name)

--- a/private/bitstring.rkt
+++ b/private/bitstring.rkt
@@ -39,7 +39,7 @@
 ;@------------------------------------------------------------------------------
 
 (define (make-bitstring-properties descriptor)
-  (define equal+hash (make-tuple-equal+hash descriptor))
+  (define equal+hash (default-tuple-equal+hash descriptor))
   (define accessor (tuple-descriptor-accessor descriptor))
   (define custom-write
     (make-constructor-style-printer

--- a/private/byte.rkt
+++ b/private/byte.rkt
@@ -124,7 +124,7 @@
   (apply byte
          (for/list ([i (in-range 8)])
            (bitwise-and (byte-ref left i)
-                        (byte-ref right i))))) 
+                        (byte-ref right i)))))
 
 (module+ test
   (test-case
@@ -144,7 +144,7 @@
   (apply byte
          (for/list ([i (in-range 8)])
            (bitwise-ior (byte-ref left i)
-                       (byte-ref right i))))) 
+                       (byte-ref right i)))))
 
 (module+ test
   (test-case
@@ -163,7 +163,7 @@
 (define (byte-not b)
   (apply byte
          (for/list ([i (in-range 8)])
-           (bitwise-xor (byte-ref b i) 1)))) 
+           (bitwise-xor (byte-ref b i) 1))))
 
 (module+ test
   (test-case
@@ -177,14 +177,14 @@
       (check-equal? (byte-ref (byte-not x) 5) (bitwise-xor (byte-ref x 5) 1))
       (check-equal? (byte-ref (byte-not x) 6) (bitwise-xor (byte-ref x 6) 1))
       (check-equal? (byte-ref (byte-not x) 7) (bitwise-xor (byte-ref x 7) 1))
-      
+
       (check-equal? (+ x (byte-not x)) 255))))
 
 (define (byte-xor left right)
   (apply byte
          (for/list ([i (in-range 8)])
            (bitwise-xor (byte-ref left i)
-                        (byte-ref right i))))) 
+                        (byte-ref right i)))))
 
 (module+ test
   (test-case
@@ -200,7 +200,7 @@
          (for/list ([i (in-range 8)])
            (bitwise-xor (bitwise-and (byte-ref left i)
                                      (byte-ref right i))
-                        1)))) 
+                        1))))
 
 (module+ test
   (test-case
@@ -221,7 +221,7 @@
          (for/list ([i (in-range 8)])
            (bitwise-xor (bitwise-ior (byte-ref left i)
                                      (byte-ref right i))
-                        1)))) 
+                        1))))
 
 (module+ test
   (test-case
@@ -242,7 +242,7 @@
          (for/list ([i (in-range 8)])
            (bitwise-xor (bitwise-xor (byte-ref left i)
                                      (byte-ref right i))
-                        1)))) 
+                        1))))
 
 (module+ test
   (test-case
@@ -251,7 +251,7 @@
       (check-equal? (byte-xnor x 0) (byte-not x))
       (check-equal? (byte-xnor x 255) x)
       (check-equal? (byte-xnor x x) 255))))
-                    
+
 (define (in-byte b)
   (list (byte-ref b 0) (byte-ref b 1) (byte-ref b 2) (byte-ref b 3)
         (byte-ref b 4) (byte-ref b 5) (byte-ref b 6) (byte-ref b 7)))

--- a/private/byte.scrbl
+++ b/private/byte.scrbl
@@ -33,7 +33,7 @@ integer between @racket[0] and @racket[255].
 @defproc[(byte-ref [b byte?] [pos (integer-in 0 7)]) bit?]{
  Returns the @tech{bit} at index @racket[pos] in @racket[b]. Indices are
  numbered from left to right and start at zero.
-                                                           
+
  @(examples
    #:eval (make-evaluator) #:once
    (byte-ref (byte 0 0 1 1 0 1 0 1) 0)
@@ -43,7 +43,7 @@ integer between @racket[0] and @racket[255].
 @defproc[(byte-clear-leftmost-bits [b byte?] [num-bits (integer-in 0 8)])
          byte?]{
  Sets the left @racket[num-bits] bits of @racket[b] to zero.
-                
+
  @(examples
    #:eval (make-evaluator) #:once
    (byte-clear-leftmost-bits (byte 1 1 1 0 1 0 1 0) 2)
@@ -53,7 +53,7 @@ integer between @racket[0] and @racket[255].
 @defproc[(byte-clear-rightmost-bits [b byte?] [num-bits (integer-in 0 8)])
          byte?]{
  Sets the right @racket[num-bits] bits of @racket[b] to zero.
-                
+
  @(examples
    #:eval (make-evaluator) #:once
    (byte-clear-rightmost-bits (byte 1 1 1 0 1 0 1 0) 2)
@@ -64,7 +64,7 @@ integer between @racket[0] and @racket[255].
          byte?]{
  Deletes the rightmost @racket[num-bits] of @racket[b], shifting all remaining
  bits to the right and inserting zeros to the left.
-                
+
  @(examples
    #:eval (make-evaluator) #:once
    (byte-drop-rightmost-bits (byte 1 1 1 0 1 0 1 0) 2)
@@ -74,18 +74,18 @@ integer between @racket[0] and @racket[255].
 @defproc[(byte-and [left byte?] [right byte?])
          byte?]{
  Performs a bitwise and operation on @racket[left] using @racket[right] as the mask. Can be used to zero out specific bits of a byte.
-  
+
  @(examples
    #:eval (make-evaluator) #:once
    (code:comment "extract the least-significant bit.")
-   (byte-and (byte 1 1 1 1 1 1 1 1) (byte 0 0 0 0 0 0 0 1)) 
+   (byte-and (byte 1 1 1 1 1 1 1 1) (byte 0 0 0 0 0 0 0 1))
    (code:comment "extract bits 7, 5, and 0.")
    (byte-and (byte 1 1 1 1 1 1 1 1) (byte 1 0 1 0 0 0 0 1)))}
 
 @defproc[(byte-or [left byte?] [right byte?])
          byte?]{
  Performs a bitwise or operation on @racket[left] using @racket[right] as the mask. Can be used to set specific bits of a byte without affecting others.
-  
+
  @(examples
    #:eval (make-evaluator) #:once
    (code:comment "set the least-significant bit")
@@ -96,7 +96,7 @@ integer between @racket[0] and @racket[255].
 @defproc[(byte-not [b byte?])
          byte?]{
  Performs a bitwise not operation on @racket[b], inverting all bits.
-  
+
  @(examples
    #:eval (make-evaluator) #:once
    (byte-not (byte 1 1 1 1 1 1 1 1))
@@ -105,7 +105,7 @@ integer between @racket[0] and @racket[255].
 @defproc[(byte-xor [left byte?] [right byte?])
          byte?]{
  Performs a bitwise xor (exclusive or, also known as eor) operation on @racket[left] using @racket[right] as the mask.
-  
+
  @(examples
    #:eval (make-evaluator) #:once
    (byte-xor (byte 0 0 0 1 0 1 0 1) (byte 0 0 1 1 1 1 1 1))
@@ -120,10 +120,10 @@ integer between @racket[0] and @racket[255].
          byte?]{
  Performs a bitwise nand operation on @racket[left] using @racket[right] as the mask.
  Equivalent to (byte-not (byte-and left right)).
-  
+
  @(examples
    #:eval (make-evaluator) #:once
-   (byte-nand (byte 1 1 1 1 1 1 1 1) (byte 1 1 1 1 1 1 1 1)) 
+   (byte-nand (byte 1 1 1 1 1 1 1 1) (byte 1 1 1 1 1 1 1 1))
    (byte-not (byte-and (byte 1 1 1 1 1 1 1 1) (byte 1 1 1 1 1 1 1 1)))
    (byte-nand (byte 0 0 0 0 0 0 0 0) (byte 0 0 0 0 0 0 0 0))
    (byte-not (byte-and (byte 0 0 0 0 0 0 0 0) (byte 0 0 0 0 0 0 0 0)))
@@ -133,10 +133,10 @@ integer between @racket[0] and @racket[255].
          byte?]{
  Performs a bitwise nor operation on @racket[left] using @racket[right] as the mask.
  Equivalent to (byte-not (byte-or left right)).
-  
+
  @(examples
    #:eval (make-evaluator) #:once
-   (byte-nor (byte 1 1 1 1 1 1 1 1) (byte 1 1 1 1 1 1 1 1)) 
+   (byte-nor (byte 1 1 1 1 1 1 1 1) (byte 1 1 1 1 1 1 1 1))
    (byte-not (byte-or (byte 1 1 1 1 1 1 1 1) (byte 1 1 1 1 1 1 1 1)))
    (byte-nor (byte 0 0 0 0 0 0 0 0) (byte 0 0 0 0 0 0 0 0))
    (byte-not (byte-or (byte 0 0 0 0 0 0 0 0) (byte 0 0 0 0 0 0 0 0)))
@@ -146,10 +146,10 @@ integer between @racket[0] and @racket[255].
          byte?]{
  Performs a bitwise xnor operation on @racket[left] using @racket[right] as the mask.
  Equivalent to (byte-not (byte-xor left right)).
-  
+
  @(examples
    #:eval (make-evaluator) #:once
-   (byte-xnor (byte 1 1 1 1 1 1 1 1) (byte 1 1 1 1 1 1 1 1)) 
+   (byte-xnor (byte 1 1 1 1 1 1 1 1) (byte 1 1 1 1 1 1 1 1))
    (byte-not (byte-xor (byte 1 1 1 1 1 1 1 1) (byte 1 1 1 1 1 1 1 1)))
    (byte-xnor (byte 0 0 0 0 0 0 0 0) (byte 0 0 0 0 0 0 0 0))
    (byte-not (byte-xor (byte 0 0 0 0 0 0 0 0) (byte 0 0 0 0 0 0 0 0))))}
@@ -157,7 +157,7 @@ integer between @racket[0] and @racket[255].
 @defproc[(in-byte [b byte?])
          sequence?]{
  Returns a sequence whose elements are equivalent to the list of bits that comprise @racket[b].
-  
+
  @(examples
    #:eval (make-evaluator) #:once
    (code:comment "convert byte to a vector of bits")
@@ -170,7 +170,7 @@ integer between @racket[0] and @racket[255].
 
 Returns the Hamming weight of the byte. This is the same as how many 1's are in the byte. See the
 @hyperlink[hamming-link]{Wikipedia page} for more informating on Hamming weight.
-  
+
  @(examples
    #:eval (make-evaluator) #:once
    (code:comment "count the number of 1's in the byte")

--- a/private/contract-projection.rkt
+++ b/private/contract-projection.rkt
@@ -19,7 +19,7 @@
 
 (define (contract-get-projection predicate blame)
   ((contract-late-neg-projection predicate) blame))
-  
+
 (define ((projection-and . projections) v missing-party)
   (for/fold ([v v]) ([p (in-list projections)])
     (p v missing-party)))

--- a/private/entry.scrbl
+++ b/private/entry.scrbl
@@ -67,7 +67,7 @@ than a collection of @racket[pair?] values.
       (list (book #:title "War and Peace" #:author "Leo Tolstoy")
             (book #:title "To the Lighthouse" #:author "Virginia Woolf")
             (book #:title "Frankenstein" #:author "Mary Shelley"))))
-   
+
    (transduce library
               (bisecting book-author book-title)
               #:into into-hash))}

--- a/private/equal+hash.scrbl
+++ b/private/equal+hash.scrbl
@@ -29,7 +29,7 @@
  functions extract @racket[size] fields from values using @racket[accessor] and
  recursively compare and hash them. This function is typically not used
  directly; instead clients are expected to use one of @racket[
- make-struct-equal+hash] or @racket[make-tuple-equal+hash].}
+ make-struct-equal+hash] or @racket[default-tuple-equal+hash].}
 
 @defthing[equal+hash/c contract?
           #:value (list/c procedure? procedure? procedure?)]

--- a/private/immutable-bytes.rkt
+++ b/private/immutable-bytes.rkt
@@ -100,18 +100,18 @@
   (define-syntax-class positional-argument
     (pattern id:id)
     (pattern [id:id default:expr]))
-  
+
   (define-syntax-class bytes-function-header
     #:attributes (id lambda-argument-binders function-call-expression)
-    
+
     (pattern (id:id arg:positional-argument ...)
       #:with lambda-argument-binders #'(arg ...)
       #:with function-call-expression #'(id arg.id ...))
-    
+
     (pattern (id:id . rest-arg:id)
       #:with lambda-argument-binders #'rest-arg
       #:with function-call-expression #'(apply id rest-arg))
-    
+
     (pattern (id:id arg:positional-argument ...+ . rest-arg:id)
       #:with lambda-argument-binders #'(arg ... . rest-arg)
       #:with function-call-expression #'(apply id arg.id ... rest-arg))))

--- a/private/immutable-string.rkt
+++ b/private/immutable-string.rkt
@@ -113,18 +113,18 @@
   (define-syntax-class positional-argument
     (pattern id:id)
     (pattern [id:id default:expr]))
-  
+
   (define-syntax-class string-function-header
     #:attributes (id lambda-argument-binders function-call-expression)
-    
+
     (pattern (id:id arg:positional-argument ...)
       #:with lambda-argument-binders #'(arg ...)
       #:with function-call-expression #'(id arg.id ...))
-    
+
     (pattern (id:id . rest-arg:id)
       #:with lambda-argument-binders #'rest-arg
       #:with function-call-expression #'(apply id rest-arg))
-    
+
     (pattern (id:id arg:positional-argument ...+ . rest-arg:id)
       #:with lambda-argument-binders #'(arg ... . rest-arg)
       #:with function-call-expression #'(apply id arg.id ... rest-arg))))

--- a/private/immutable-vector.rkt
+++ b/private/immutable-vector.rkt
@@ -84,18 +84,18 @@
   (define-syntax-class positional-argument
     (pattern id:id)
     (pattern [id:id default:expr]))
-  
+
   (define-syntax-class vector-function-header
     #:attributes (id lambda-argument-binders function-call-expression)
-    
+
     (pattern (id:id arg:positional-argument ...)
       #:with lambda-argument-binders #'(arg ...)
       #:with function-call-expression #'(id arg.id ...))
-    
+
     (pattern (id:id . rest-arg:id)
       #:with lambda-argument-binders #'rest-arg
       #:with function-call-expression #'(apply id rest-arg))
-    
+
     (pattern (id:id arg:positional-argument ...+ . rest-arg:id)
       #:with lambda-argument-binders #'(arg ... . rest-arg)
       #:with function-call-expression #'(apply id arg.id ... rest-arg))))

--- a/private/keyset.rkt
+++ b/private/keyset.rkt
@@ -55,14 +55,14 @@
   #:omit-define-syntaxes
 
   #:property prop:sequence (λ (this) (in-keyset this))
-  
+
   #:methods gen:equal+hash
   [(define (equal-proc this other recur)
      (recur (keyset-sorted-vector this) (keyset-sorted-vector other)))
    (define (hash-proc this recur)
      (recur (list keyset-datatype-token (keyset-sorted-vector this))))
    (define hash2-proc hash-proc)]
-  
+
   #:methods gen:custom-write [(define write-proc write-keyset)])
 
 (define (keyset-size keys)

--- a/private/markup.rkt
+++ b/private/markup.rkt
@@ -46,7 +46,7 @@
      (λ (this) (accessor this type-name-field))
      (λ (this) (accessor this subexpressions-field))))
   (list (cons prop:custom-write custom-write)
-        (cons prop:equal+hash (make-record-equal+hash descriptor))))
+        (cons prop:equal+hash (default-record-equal+hash descriptor))))
 
 (define (make-keyword-markup-properties descriptor)
   (define accessor (wrapper-descriptor-accessor descriptor))

--- a/private/media.rkt
+++ b/private/media.rkt
@@ -48,7 +48,7 @@
 (define (make-media-type-properties descriptor)
   (define name (tuple-type-name (tuple-descriptor-type descriptor)))
   (define accessor (tuple-descriptor-accessor descriptor))
-  (define equal+hash (make-tuple-equal+hash descriptor))
+  (define equal+hash (default-tuple-equal+hash descriptor))
   (define custom-write
     (make-constructor-style-printer
      (λ (_) name)

--- a/private/multidict.rkt
+++ b/private/multidict.rkt
@@ -79,7 +79,7 @@
   (define backing-hash-field
     (keyset-index-of (record-type-fields type) '#:backing-hash))
   (define accessor (record-descriptor-accessor descriptor))
-  (define equal+hash (make-record-equal+hash descriptor))
+  (define equal+hash (default-record-equal+hash descriptor))
   (define custom-write
     (make-constructor-style-printer
      (λ (_) type-name)

--- a/private/multidict.rkt
+++ b/private/multidict.rkt
@@ -216,13 +216,13 @@
     (check-equal?
      (multidict-replace-values (multidict 'a 4 'b 2) 'a (list 1 2 2 3))
      (multidict 'a 1 'a 2 'a 3 'b 2)))
-  
+
   (test-case "multidict-add"
     (check-equal? (multidict-add empty-multidict 'a 1) (multidict 'a 1))
     (check-equal? (multidict-add (multidict 'a 1) 'b 2) (multidict 'a 1 'b 2))
     (check-equal? (multidict-add (multidict 'a 1) 'a 2) (multidict 'a 1 'a 2))
     (check-equal? (multidict-add (multidict 'a 1) 'a 1) (multidict 'a 1)))
-  
+
   (test-case "multidict-add-entry"
     (check-equal? (multidict-add-entry empty-multidict (entry 'a 1))
                   (multidict 'a 1))
@@ -232,7 +232,7 @@
                   (multidict 'a 1 'a 2))
     (check-equal? (multidict-add-entry (multidict 'a 1) (entry 'a 1))
                   (multidict 'a 1)))
-  
+
   (test-case "multidict-remove"
     (check-equal? (multidict-remove (multidict 'a 1 'b 2) 'a 1)
                   (multidict 'b 2))
@@ -241,7 +241,7 @@
     (check-equal? (multidict-remove (multidict 'a 1) 'a 1) empty-multidict)
     (check-equal? (multidict-remove (multidict 'a 1 'b 2) 'c 3)
                   (multidict 'a 1 'b 2)))
-  
+
   (test-case "multidict-remove-entry"
     (check-equal? (multidict-remove-entry (multidict 'a 1 'b 2) (entry 'a 1))
                   (multidict 'b 2))
@@ -282,7 +282,7 @@
    #:inverted-hash (multidict-backing-hash dict)
    #:keys (multidict-values dict)
    #:values (multidict-keys dict)))
-  
+
 (define (multidict-ref dict k) (hash-ref (multidict-backing-hash dict) k (set)))
 
 (define (multidict-contains-key? dict k)

--- a/private/multidict.scrbl
+++ b/private/multidict.scrbl
@@ -37,7 +37,7 @@ interface is based on a flattened collection of key-value pairs.
  @racket[v]. Multiple values are allowed for the same key, but duplicate values
  for a key are removed. The order of key-value pairs is insignificant. Two
  multidicts are equal if they contain the same mappings.
-                                                             
+
  @(examples
    #:eval (make-evaluator) #:once
    (multidict 'a 1 'b 2 'c 3)
@@ -115,7 +115,7 @@ interface is based on a flattened collection of key-value pairs.
  Returns the number of key-value mappings in @racket[dict]. Note that this does
  @bold{not} return the number of keys in @racket[dict] --- all values mapped by
  a key contribute to the returned size.
-                                                      
+
  @(examples
    #:eval (make-evaluator) #:once
    (multidict-size (multidict 'a 1 'b 2 'c 3))
@@ -124,7 +124,7 @@ interface is based on a flattened collection of key-value pairs.
 
 @defproc[(multidict-ref [dict multidict?] [k any/c]) immutable-set?]{
  Returns the set of values mapped by @racket[k] in @racket[dict].
-                                                                     
+
  @(examples
    #:eval (make-evaluator) #:once
    (define dict
@@ -140,7 +140,7 @@ interface is based on a flattened collection of key-value pairs.
 @defproc[(multidict-keys [dict multidict?]) multiset?]{
  Returns a @tech{multiset} of the keys in @racket[dict], with a copy of each
  key for each value mapped by that key.
-                                                       
+
  @(examples
    #:eval (make-evaluator) #:once
    (multidict-keys
@@ -152,7 +152,7 @@ interface is based on a flattened collection of key-value pairs.
 
 @defproc[(multidict-values [dict multidict?]) multiset?]{
  Returns a @tech{multiset} of all values in @racket[dict].
-                                                         
+
  @(examples
    #:eval (make-evaluator) #:once
    (multidict-values
@@ -165,7 +165,7 @@ interface is based on a flattened collection of key-value pairs.
 
 @defproc[(multidict-unique-keys [dict multidict?]) immutable-set?]{
  Returns the set of keys in @racket[dict], ignoring duplicates.
-                                                                   
+
  @(examples
    #:eval (make-evaluator) #:once
    (multidict-unique-keys
@@ -177,7 +177,7 @@ interface is based on a flattened collection of key-value pairs.
 
 @defproc[(multidict-unique-values [dict multidict?]) immutable-set?]{
  Returns the set of values in @racket[dict], ignoring duplicates.
-                                                                   
+
   @(examples
    #:eval (make-evaluator) #:once
    (multidict-unique-values

--- a/private/multiset.rkt
+++ b/private/multiset.rkt
@@ -141,7 +141,7 @@
                   (multiset 1 1 2 2 3 3)))
 
   (test-case "multiset-set-frequency"
-    
+
     (test-case "clearing-already-empty"
       (define set (multiset-set-frequency empty-multiset 'a 0))
       (check-equal? (multiset-size set) 0))
@@ -153,7 +153,7 @@
     (test-case "setting-empty-to-many"
       (define set (multiset-set-frequency empty-multiset 'a 5))
       (check-equal? (multiset-size set) 5))
-      
+
     (test-case "one-unique-element"
       (define set (multiset 'a 'a 'a))
       (check-equal? (multiset-size (multiset-set-frequency set 'a 0)) 0)
@@ -169,7 +169,7 @@
       (check-equal? (multiset-size (set-to-zero 'b)) 3)
       (check-equal? (multiset-size (set-to-zero 'c)) 5)
       (check-equal? (multiset-size (set-to-zero 'd)) 6))
-    
+
     (test-case "equality"
       (define set (multiset 'a 'b 'c))
       (check-equal? (multiset-size (multiset-set-frequency set 'a 3)) 5)
@@ -178,7 +178,7 @@
       (check-equal? (multiset-set-frequency set 'a 0) (multiset 'b 'c))
       (check-equal? (multiset-set-frequency set 'd 2) (multiset 'a 'b 'c 'd 'd))
       (check-equal? (multiset-set-frequency set 'd 0) set)))
-  
+
   (test-case "multiset-remove"
 
     (test-case "single-copy"
@@ -186,7 +186,7 @@
       (check-equal? (multiset-remove set 'a) (multiset 'b 'b 'c))
       (check-equal? (multiset-remove set 'b) (multiset 'a 'b 'c))
       (check-equal? (multiset-remove set 'd) set))
-    
+
     (test-case "multiple-copies"
       (define set (multiset 'a 'a 'b 'b 'b 'c))
       (check-equal? (multiset-remove set 'a #:copies 2) (multiset 'b 'b 'b 'c))
@@ -195,13 +195,13 @@
                     (multiset 'a 'a 'b 'b 'b))
       (check-equal? (multiset-remove set 'b #:copies 3) (multiset 'a 'a 'c))
       (check-equal? (multiset-remove set 'd #:copies 5) set))
-    
+
     (test-case "zero-copies"
       (define set (multiset 'a 'b 'b 'c))
       (check-equal? (multiset-remove set 'a #:copies 0) set)
       (check-equal? (multiset-remove set 'b #:copies 0) set)
       (check-equal? (multiset-remove set 'd #:copies 0) set))
-    
+
     (test-case "all-copies"
       (define set (multiset 'a 'b 'b 'c))
       (check-equal? (multiset-remove set 'a #:copies +inf.0)

--- a/private/multiset.rkt
+++ b/private/multiset.rkt
@@ -57,7 +57,7 @@
 
 (define (make-multiset-props descriptor)
   (define name (record-type-name (record-descriptor-type descriptor)))
-  (define equal+hash (make-record-equal+hash descriptor))
+  (define equal+hash (default-record-equal+hash descriptor))
   (define custom-write
     (make-constructor-style-printer
      (λ (_) name)

--- a/private/octet-stream.scrbl
+++ b/private/octet-stream.scrbl
@@ -48,7 +48,7 @@ is @racket[application/octet-stream].
 
 @defproc[(octet-stream->bitstring [octets octet-stream?]) bitstring?]{
  Converts @racket[octets] into a @tech{bitstring}.
-          
+
  @(examples
    #:eval (make-evaluator) #:once
    (octet-stream->bitstring (octet-stream #"Apple"))

--- a/private/permutation.rkt
+++ b/private/permutation.rkt
@@ -42,7 +42,7 @@
     (make-constructor-style-printer
      (λ (_) type-name)
      (λ (this) (accessor this 0))))
-  (list (cons prop:equal+hash (make-tuple-equal+hash descriptor))
+  (list (cons prop:equal+hash (default-tuple-equal+hash descriptor))
         (cons prop:custom-write custom-write)))
 
 (define-tuple-type permutation (vector)

--- a/private/record-type-descriptor.rkt
+++ b/private/record-type-descriptor.rkt
@@ -16,9 +16,9 @@
   [record-descriptor-predicate (-> record-descriptor? predicate/c)]
   [record-descriptor-constructor (-> record-descriptor? procedure?)]
   [record-descriptor-accessor (-> record-descriptor? procedure?)]
-  [make-default-record-properties (-> record-descriptor? properties/c)]
-  [make-record-equal+hash (-> record-descriptor? equal+hash/c)]
-  [make-record-custom-write (-> record-descriptor? custom-write-function/c)]
+  [default-record-properties (-> record-descriptor? properties/c)]
+  [default-record-equal+hash (-> record-descriptor? equal+hash/c)]
+  [default-record-custom-write (-> record-descriptor? custom-write-function/c)]
   [make-record-field-accessor (-> record-descriptor? natural? procedure?)]))
 
 (require racket/math
@@ -67,7 +67,7 @@
 (define (make-record-implementation
          type
          #:inspector [inspector (current-inspector)]
-         #:property-maker [prop-maker make-default-record-properties])
+         #:property-maker [prop-maker default-record-properties])
   (define (tuple-prop-maker descriptor)
     (prop-maker (tuple-descriptor->record-descriptor descriptor type)))
   (define descriptor
@@ -101,13 +101,13 @@
   (define accessor (tuple-descriptor-accessor descriptor))
   (maker type predicate constructor accessor))
 
-(define (make-default-record-properties descriptor)
-  (define equal+hash (make-record-equal+hash descriptor))
-  (define custom-write (make-record-custom-write descriptor))
+(define (default-record-properties descriptor)
+  (define equal+hash (default-record-equal+hash descriptor))
+  (define custom-write (default-record-custom-write descriptor))
   (list (cons prop:equal+hash equal+hash)
         (cons prop:custom-write custom-write)))
 
-(define (make-record-equal+hash descriptor)
+(define (default-record-equal+hash descriptor)
   (define accessor (record-descriptor-accessor descriptor))
   (define size
     (keyset-size (record-type-fields (record-descriptor-type descriptor))))
@@ -116,7 +116,7 @@
 (define (unquoted-printing-keyword kw)
   (unquoted-printing-string (string-append "#:" (keyword->string kw))))
 
-(define (make-record-custom-write descriptor)
+(define (default-record-custom-write descriptor)
   (define type (record-descriptor-type descriptor))
   (define type-name (record-type-name type))
   (define accessor (record-descriptor-accessor descriptor))

--- a/private/record-type.rkt
+++ b/private/record-type.rkt
@@ -26,7 +26,7 @@
                      #:defaults ([constructor-name #'id])
                      #:name "#:constructor-name option")
           (~optional (~seq #:property-maker prop-maker:expr)
-                     #:defaults ([prop-maker #'make-default-record-properties])
+                     #:defaults ([prop-maker #'default-record-properties])
                      #:name "#:property-maker option"))
     ...)
   #:with fields

--- a/private/record-type.scrbl
+++ b/private/record-type.scrbl
@@ -95,7 +95,7 @@ obvious order to those pieces.
           [#:property-maker prop-maker
            (-> uninitialized-record-descriptor?
                (listof (cons/c struct-type-property? any/c)))
-           make-default-record-properties])
+           default-record-properties])
          initialized-record-descriptor?]
 
 @defproc[(record-descriptor? [v any/c]) boolean?]
@@ -117,10 +117,10 @@ obvious order to those pieces.
                                      [field natural?])
          (-> (record-descriptor-predicate descriptor) any/c)]
 
-@defproc[(make-default-record-properties [descriptor record-descriptor?])
+@defproc[(default-record-properties [descriptor record-descriptor?])
          (listof (cons/c struct-type-property? any/c))]
 
-@defproc[(make-record-equal+hash [descriptor record-descriptor?]) equal+hash/c]
+@defproc[(default-record-equal+hash [descriptor record-descriptor?]) equal+hash/c]
 
-@defproc[(make-record-custom-write [descriptor record-descriptor?])
+@defproc[(default-record-custom-write [descriptor record-descriptor?])
          custom-write-function/c]

--- a/private/record.rkt
+++ b/private/record.rkt
@@ -52,7 +52,7 @@
                    [v (in-vector values)])
           (define kw-str (unquoted-printing-string (format "~s" kw)))
           (spliced-printing-entry kw-str v)))))
-  (list (cons prop:equal+hash (make-tuple-equal+hash descriptor))
+  (list (cons prop:equal+hash (default-tuple-equal+hash descriptor))
         (cons prop:custom-write custom-write)))
 
 (define-tuple-type record (keywords values)
@@ -175,7 +175,7 @@
 (define (make-record-field-properties descriptor)
   (define type-name (tuple-type-name (tuple-descriptor-type descriptor)))
   (define accessor (tuple-descriptor-accessor descriptor))
-  (define equal+hash (make-tuple-equal+hash descriptor))
+  (define equal+hash (default-tuple-equal+hash descriptor))
   (define custom-write
     (make-constructor-style-printer
      (λ (_) type-name)

--- a/private/reducer.rkt
+++ b/private/reducer.rkt
@@ -372,7 +372,7 @@
          (variant #:consume (add1 index-counter))))
    #:finisher (λ (_) absent)
    #:early-finisher (λ (index-counter) (present index-counter))
-   #:name name))   
+   #:name name))
 
 (module+ test
   (test-case "into-nth"

--- a/private/reducer.scrbl
+++ b/private/reducer.scrbl
@@ -147,7 +147,7 @@ fully consumed.
    (reduce-all (into-max) (in-range 1 10))
    (reduce-all (into-min) (in-range 1 10))
    (reduce-all (into-max) empty-list)
-   
+
    (reduce (into-min string<=>) "goodbye" "cruel" "world")
 
    (define-record-type gemstone (color weight))
@@ -325,7 +325,7 @@ reducers with increasing power and complexity:
    (define into-total-letters
      (reducer-map into-sum #:domain string-length))
    (reduce into-total-letters "the" "quick" "brown" "fox")
-   
+
    (define stringly-typed-into-sum
      (reducer-map into-sum
                   #:domain string->number

--- a/private/reference-type-descriptor.rkt
+++ b/private/reference-type-descriptor.rkt
@@ -18,12 +18,12 @@
                               (listof (cons/c struct-type-property? any/c)))
          #:inspector inspector?)
         initialized-reference-descriptor?)]
-  [make-default-reference-properties
+  [default-reference-properties
    (-> reference-descriptor? (listof (cons/c struct-type-property? any/c)))]
-  [make-default-reference-equal+hash (-> reference-descriptor? equal+hash/c)]
-  [make-default-reference-custom-write
+  [default-reference-equal+hash (-> reference-descriptor? equal+hash/c)]
+  [default-reference-custom-write
    (-> reference-descriptor? custom-write-function/c)]
-  [make-default-reference-object-name (-> reference-descriptor? natural?)]
+  [default-reference-object-name (-> reference-descriptor? natural?)]
   [make-reference-field-accessor
    (-> reference-descriptor? keyword? procedure?)]))
 
@@ -46,7 +46,7 @@
   (define (name-getter this) (reference-type-name (accessor this type-field)))
   (define custom-write
     (make-named-object-custom-write type-name #:name-getter name-getter))
-  (list (cons prop:equal+hash (make-record-equal+hash descriptor))
+  (list (cons prop:equal+hash (default-record-equal+hash descriptor))
         (cons prop:custom-write custom-write)
         (cons prop:object-name name-getter)))
 
@@ -131,7 +131,7 @@
 
 (define (make-reference-implementation
          type
-         #:property-maker [prop-maker make-default-reference-properties]
+         #:property-maker [prop-maker default-reference-properties]
          #:inspector [inspector (current-inspector)])
   (define (tuple-prop-maker descriptor)
     (prop-maker (tuple-descriptor->reference-descriptor descriptor type)))
@@ -141,24 +141,24 @@
                               #:inspector inspector)
    type))
 
-(define (make-default-reference-properties descriptor)
-  (list (cons prop:equal+hash (make-default-reference-equal+hash descriptor))
+(define (default-reference-properties descriptor)
+  (list (cons prop:equal+hash (default-reference-equal+hash descriptor))
         (cons prop:custom-write
-              (make-default-reference-custom-write descriptor))
+              (default-reference-custom-write descriptor))
         (cons prop:object-name
-              (make-default-reference-object-name descriptor))))
+              (default-reference-object-name descriptor))))
 
-(define (make-default-reference-equal+hash descriptor)
+(define (default-reference-equal+hash descriptor)
   (define accessor (reference-descriptor-accessor descriptor))
   (define size (reference-type-size (reference-descriptor-type descriptor)))
   (make-accessor-based-equal+hash accessor size))
 
-(define (make-default-reference-custom-write descriptor)
+(define (default-reference-custom-write descriptor)
   (define type-name
     (reference-type-name (reference-descriptor-type descriptor)))
   (make-named-object-custom-write type-name))
 
-(define (make-default-reference-object-name descriptor)
+(define (default-reference-object-name descriptor)
   (reference-type-object-name-field (reference-descriptor-type descriptor)))
 
 (define (make-reference-field-accessor descriptor field)

--- a/private/reference-type.rkt
+++ b/private/reference-type.rkt
@@ -48,7 +48,7 @@
                      #:defaults
                      ([prop-maker #'default-reference-properties])))
     ...)
-  
+
   #:with (field* ...) (cons (syntax-local-introduce #'name)
                             (syntax->list #'(field ...)))
   #:with (field-kw ...)

--- a/private/reference-type.rkt
+++ b/private/reference-type.rkt
@@ -46,7 +46,7 @@
           (~optional (~seq #:property-maker prop-maker:expr)
                      #:name "#:property-maker option"
                      #:defaults
-                     ([prop-maker #'make-default-reference-properties])))
+                     ([prop-maker #'default-reference-properties])))
     ...)
   
   #:with (field* ...) (cons (syntax-local-introduce #'name)

--- a/private/reference-type.scrbl
+++ b/private/reference-type.scrbl
@@ -46,7 +46,7 @@
           [#:property-maker prop-maker
            (-> uninitialized-reference-descriptor?
                (listof (cons/c struct-type-property? any/c)))
-           make-default-reference-properties]
+           default-reference-properties]
           [#:inspector inspector inspector? (current-inspector)])
          initialized-reference-descriptor?]
 
@@ -84,15 +84,15 @@
 
 @section{Reference Type Properties}
 
-@defproc[(make-default-reference-properties [descriptor reference-descriptor?])
+@defproc[(default-reference-properties [descriptor reference-descriptor?])
          (listof (cons/c struct-type-property? any/c))]
 
-@defproc[(make-default-reference-equal+hash [descriptor reference-descriptor?])
+@defproc[(default-reference-equal+hash [descriptor reference-descriptor?])
          equal+hash/c]
 
-@defproc[(make-default-reference-custom-write
+@defproc[(default-reference-custom-write
           [descriptor reference-descriptor?])
          custom-write-function/c]
 
-@defproc[(make-default-reference-object-name [descriptor reference-descriptor?])
+@defproc[(default-reference-object-name [descriptor reference-descriptor?])
          natural?]

--- a/private/singleton-type-descriptor.rkt
+++ b/private/singleton-type-descriptor.rkt
@@ -15,7 +15,7 @@
   [uninitialized-singleton-descriptor? predicate/c]
   [singleton-descriptor-instance (-> initialized-singleton-descriptor? any/c)]
   [singleton-descriptor-predicate (-> singleton-descriptor? predicate/c)]
-  [make-default-singleton-properties
+  [default-singleton-properties
    (-> uninitialized-singleton-descriptor?
        (listof (cons/c struct-type-property? any/c)))]))
 
@@ -59,7 +59,7 @@
 (define (make-singleton-implementation
          type
          #:inspector [inspector (current-inspector)]
-         #:property-maker [prop-maker make-default-singleton-properties])
+         #:property-maker [prop-maker default-singleton-properties])
   (define (make-tuple-props tuple-descriptor)
     (define predicate (tuple-descriptor-predicate tuple-descriptor))
     (prop-maker
@@ -76,7 +76,7 @@
                                     #:instance instance
                                     #:predicate pred))
 
-(define (make-default-singleton-properties descriptor)
+(define (default-singleton-properties descriptor)
   (define name (singleton-type-name (singleton-descriptor-type descriptor)))
   (list (cons prop:object-name (λ (_) name))
         (cons prop:equal+hash (make-singleton-equal+hash))

--- a/private/singleton-type.rkt
+++ b/private/singleton-type.rkt
@@ -54,7 +54,7 @@
           (~optional (~seq #:property-maker prop-maker:expr)
                      #:name "#:property-maker option"
                      #:defaults
-                     ([prop-maker #'make-default-singleton-properties])))
+                     ([prop-maker #'default-singleton-properties])))
     ...)
   (begin
     (define type (singleton-type 'name #:predicate-name 'predicate))

--- a/private/singleton-type.scrbl
+++ b/private/singleton-type.scrbl
@@ -84,7 +84,7 @@ of the constant causes a compile error rather than a silent bug at runtime.
           [#:property-maker prop-maker
            (-> uninitialized-singleton-descriptor?
                (listof (cons/c struct-type-property? any/c)))
-           make-default-singleton-properties])
+           default-singleton-properties])
          initialized-singleton-descriptor?]
 
 @defproc[(singleton-descriptor? [v any/c]) boolean?]
@@ -100,5 +100,5 @@ of the constant causes a compile error rather than a silent bug at runtime.
           [descriptor initialized-singleton-descriptor?])
          (singleton-descriptor-predicate descriptor)]
 
-@defproc[(make-default-singleton-properties [descriptor singleton-descriptor?])
+@defproc[(default-singleton-properties [descriptor singleton-descriptor?])
          (listof (cons/c struct-type-property? any/c))]

--- a/private/table.rkt
+++ b/private/table.rkt
@@ -137,7 +137,7 @@
              (row "Greece" 10800000 "Athens")
              (row "Nigeria" 198600000 "Abuja")
              (row "Japan" 126400000 "Tokyo")))
-  
+
   (test-case "table-ref"
     (check-equal? (table-ref countries 0 '#:name) "Argentina")
     (check-equal? (table-ref countries 2 '#:population) 198600000)

--- a/private/table.rkt
+++ b/private/table.rkt
@@ -74,7 +74,7 @@
 (define (make-table-properties descriptor)
   (list (cons prop:custom-write write-table)
         (cons prop:sequence in-table)
-        (cons prop:equal+hash (make-record-equal+hash descriptor))))
+        (cons prop:equal+hash (default-record-equal+hash descriptor))))
 
 (define-record-type table (backing-column-vectors size)
   #:constructor-name constructor:table

--- a/private/text.scrbl
+++ b/private/text.scrbl
@@ -32,7 +32,7 @@ the two is in how character encoding and decoding are handled:
  @item{Strings are all encoded with the same charset, which is a Unicode
   encoding internal to Racket. Conversion between strings and bytes requires
   explicitly reencoding the string.}
-  
+
  @item{Text values specify their charset directly, and different text values can
   have different charsets. Constructing a text value from bytes doesn't require
   performing any decoding --- that's only needed when changing the text's

--- a/private/transducer.rkt
+++ b/private/transducer.rkt
@@ -49,7 +49,7 @@
 ;; types. The function statements are listed in order of when they're called for
 ;; each output element of the sequence (i.e. the pos->element function is called
 ;; before early-next-pos and after continue-with-pos?).
-;; 
+;;
 ;; init-pos : P (I think? might be Q? seems like P is the only sensible choice)
 ;;
 ;; P -> continue-with-pos?

--- a/private/tuple-type-descriptor.rkt
+++ b/private/tuple-type-descriptor.rkt
@@ -5,11 +5,11 @@
 (provide
  (contract-out
   [initialized-tuple-descriptor? (-> any/c boolean?)]
-  [make-default-tuple-properties
+  [default-tuple-properties
    (-> uninitialized-tuple-descriptor?
        (listof (cons/c struct-type-property? any/c)))]
-  [make-tuple-equal+hash (-> tuple-descriptor? equal+hash/c)]
-  [make-tuple-custom-write (-> tuple-descriptor? custom-write-function/c)]
+  [default-tuple-equal+hash (-> tuple-descriptor? equal+hash/c)]
+  [default-tuple-custom-write (-> tuple-descriptor? custom-write-function/c)]
   [make-tuple-field-accessor
    (->i ([desc () tuple-descriptor?]
          [pos (desc)
@@ -63,12 +63,12 @@
   (list (cons prop:equal+hash equal+hash)
         (cons prop:custom-write custom-write)))
 
-(define (make-tuple-equal+hash descriptor)
+(define (default-tuple-equal+hash descriptor)
   (define accessor (tuple-descriptor-accessor descriptor))
   (define size (tuple-type-size (tuple-descriptor-type descriptor)))
   (make-accessor-based-equal+hash accessor size))
 
-(define (make-tuple-custom-write descriptor)
+(define (default-tuple-custom-write descriptor)
   (define type (tuple-descriptor-type descriptor))
   (define type-name (tuple-type-name type))
   (define size (tuple-type-size type))
@@ -77,9 +77,9 @@
    (λ (_) type-name)
    (λ (this) (build-list size (λ (pos) (accessor this pos))))))
 
-(define (make-default-tuple-properties descriptor)
-  (list (cons prop:equal+hash (make-tuple-equal+hash descriptor))
-        (cons prop:custom-write (make-tuple-custom-write descriptor))))
+(define (default-tuple-properties descriptor)
+  (list (cons prop:equal+hash (default-tuple-equal+hash descriptor))
+        (cons prop:custom-write (default-tuple-custom-write descriptor))))
 
 ;@------------------------------------------------------------------------------
 
@@ -181,7 +181,7 @@
          type
          #:guard [guard #f]
          #:inspector [inspector (current-inspector)]
-         #:property-maker [prop-maker make-default-tuple-properties])
+         #:property-maker [prop-maker default-tuple-properties])
   (define (get-predicate descriptor)
     (procedure-rename (struct-descriptor-predicate descriptor)
                       (tuple-type-predicate-name type)))

--- a/private/tuple-type.rkt
+++ b/private/tuple-type.rkt
@@ -19,7 +19,7 @@
                                   (format-id #'id "~a?" (syntax-e #'id))]))
           (~optional (~seq #:property-maker property-maker:expr)
                      #:defaults ([property-maker
-                                  #'make-default-tuple-properties])))
+                                  #'default-tuple-properties])))
     ...)
   #:do [(define size (length (syntax->list #'(field ...))))]
   #:with quoted-size #`(quote #,size)

--- a/private/tuple-type.scrbl
+++ b/private/tuple-type.scrbl
@@ -96,7 +96,7 @@ distinct implementations of that type.
   [#:property-maker prop-maker
    (-> uninitialized-tuple-descriptor?
        (listof (cons/c struct-type-property? any/c)))
-   make-default-tuple-properties])
+   default-tuple-properties])
  initialized-tuple-descriptor?]{
  Implements @racket[type] and returns a @tech{tuple type descriptor} for the
  new implementation. The @racket[guard] and @racket[inspector] arguments behave
@@ -105,7 +105,7 @@ distinct implementations of that type.
  argument is similar to the corresponding argument of @racket[
  make-struct-implementation]. By default, tuple types are created with
  properties that make them print and compare in a manner similar to transparent
- structure types --- see @racket[make-default-tuple-properties] for details.
+ structure types --- see @racket[default-tuple-properties] for details.
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -131,14 +131,14 @@ distinct implementations of that type.
  examples.}
 
 @defproc[
- (make-default-tuple-properties [descriptor uninitialized-tuple-descriptor?])
+ (default-tuple-properties [descriptor uninitialized-tuple-descriptor?])
  (listof (cons/c struct-type-property? any/c))]{
  Returns implementations of @racket[prop:equal+hash] and @racket[
  prop:custom-write] suitable for most @tech{tuple types}. This function is
  called by @racket[make-tuple-implementation] when no @racket[_prop-maker]
  argument is supplied.}
 
-@defproc[(make-tuple-equal+hash [descriptor tuple-descriptor?])
+@defproc[(default-tuple-equal+hash [descriptor tuple-descriptor?])
          equal+hash/c]{
  Builds an equality-checking function, a hashing function, and a secondary
  hashing function suitable for use with @racket[prop:equal+hash], each of which
@@ -151,11 +151,11 @@ distinct implementations of that type.
    (define-tuple-type point (x y)
      #:property-maker
      (λ (descriptor)
-       (list (cons prop:equal+hash (make-tuple-equal+hash descriptor)))))
+       (list (cons prop:equal+hash (default-tuple-equal+hash descriptor)))))
    (equal? (point 1 2) (point 1 2))
    (equal? (point 1 2) (point 2 1)))}
 
-@defproc[(make-tuple-custom-write [descriptor tuple-descriptor?])
+@defproc[(default-tuple-custom-write [descriptor tuple-descriptor?])
          custom-write-function/c]{
  Constructs a @tech{custom write implementation} that prints instances of the
  @tech{tuple type} described by @racket[descriptor] in a manner similar to the
@@ -166,7 +166,7 @@ distinct implementations of that type.
    (define-tuple-type point (x y)
      #:property-maker
      (λ (descriptor)
-       (define custom-write (make-tuple-custom-write descriptor))
+       (define custom-write (default-tuple-custom-write descriptor))
        (list (cons prop:custom-write custom-write))))
 
    (point 1 2)

--- a/private/type.scrbl
+++ b/private/type.scrbl
@@ -123,7 +123,7 @@ provided. As a result various related features, such as integration with
 @racket[match] are not provided by any @racketmodname[rebellion/type] modules.
 However, both a basic represention of compile-time type information and
 integration with @racket[match] are intended to happen eventually. More advanced
-functionality such as a full static type system and compile-time type checker 
+functionality such as a full static type system and compile-time type checker
 are out of scope for now, but it is hoped that such an effort can either build
 on or integrate with this library.
 

--- a/private/variant.rkt
+++ b/private/variant.rkt
@@ -33,7 +33,7 @@
         (define tag-str (string-append "#:" (keyword->string tag)))
         (list (unquoted-printing-string tag-str) value))))
   (list (cons prop:custom-write custom-write)
-        (cons prop:equal+hash (make-tuple-equal+hash descriptor))))
+        (cons prop:equal+hash (default-tuple-equal+hash descriptor))))
 
 (define-tuple-type variant (tag value)
   #:constructor-name constructor:variant

--- a/private/web-graph.rkt
+++ b/private/web-graph.rkt
@@ -24,7 +24,7 @@
 (define (property-maker descriptor)
   (define name (tuple-type-name (tuple-descriptor-type descriptor)))
   (define accessor (tuple-descriptor-accessor descriptor))
-  (define equal+hash (make-tuple-equal+hash descriptor))
+  (define equal+hash (default-tuple-equal+hash descriptor))
   (define custom-write
     (make-constructor-style-printer
      (λ (_) name)

--- a/private/web-link.rkt
+++ b/private/web-link.rkt
@@ -38,7 +38,7 @@
 (define (property-maker descriptor)
   (define name (tuple-type-name (tuple-descriptor-type descriptor)))
   (define accessor (tuple-descriptor-accessor descriptor))
-  (define equal+hash (make-tuple-equal+hash descriptor))
+  (define equal+hash (default-tuple-equal+hash descriptor))
   (define custom-write
     (make-constructor-style-printer
      (λ (_) name)

--- a/private/wrapper-type-descriptor.rkt
+++ b/private/wrapper-type-descriptor.rkt
@@ -16,7 +16,7 @@
   [wrapper-descriptor-constructor (-> wrapper-descriptor? (-> any/c any/c))]
   [wrapper-descriptor-predicate (-> wrapper-descriptor? predicate/c)]
   [wrapper-descriptor-accessor (-> wrapper-descriptor? (-> any/c any/c))]
-  [make-default-wrapper-properties
+  [default-wrapper-properties
    (-> uninitialized-wrapper-descriptor?
        (listof (cons/c struct-type-property? any/c)))]))
 
@@ -60,7 +60,7 @@
 
 (define (make-wrapper-implementation
          type
-         #:property-maker [prop-maker make-default-wrapper-properties]
+         #:property-maker [prop-maker default-wrapper-properties]
          #:inspector [inspector (current-inspector)])
   (define tuple-impl-type
     (tuple-type (wrapper-type-name type) 1
@@ -97,16 +97,16 @@
   (define hash2-proc hash-proc)
   (list equal-proc hash-proc hash2-proc))
 
-(define (make-wrapper-equal+hash descriptor)
+(define (default-wrapper-equal+hash descriptor)
   (make-delegating-equal+hash (wrapper-descriptor-accessor descriptor)))
 
-(define (make-wrapper-custom-write descriptor)
+(define (default-wrapper-custom-write descriptor)
   (define type-name (wrapper-type-name (wrapper-descriptor-type descriptor)))
   (define accessor (wrapper-descriptor-accessor descriptor))
   (make-constructor-style-printer
      (λ (_) type-name)
      (λ (this) (list (accessor this)))))
 
-(define (make-default-wrapper-properties descriptor)
-  (list (cons prop:equal+hash (make-wrapper-equal+hash descriptor))
-        (cons prop:custom-write (make-wrapper-custom-write descriptor))))
+(define (default-wrapper-properties descriptor)
+  (list (cons prop:equal+hash (default-wrapper-equal+hash descriptor))
+        (cons prop:custom-write (default-wrapper-custom-write descriptor))))

--- a/private/wrapper-type.rkt
+++ b/private/wrapper-type.rkt
@@ -28,7 +28,7 @@
                                   (format-id #'id "~a-value" #'id)])
                      #:name "#:accessor-name option")
           (~optional (~seq #:property-maker prop-maker:expr)
-                     #:defaults ([prop-maker #'make-default-wrapper-properties])
+                     #:defaults ([prop-maker #'default-wrapper-properties])
                      #:name "#:property-maker option"))
     ...)
   (begin

--- a/private/wrapper-type.scrbl
+++ b/private/wrapper-type.scrbl
@@ -36,7 +36,7 @@ distinguished.
    (define/contract (celsius->fahrenheit c)
      (-> celsius? fahrenheit?)
      (fahrenheit (+ (* (celsius-value c) 9/5) 32))))
-  
+
   (celsius->fahrenheit (celsius 0))
   (celsius->fahrenheit (celsius 100))
   (eval:error (celsius->fahrenheit (fahrenheit 100))))

--- a/private/wrapper-type.scrbl
+++ b/private/wrapper-type.scrbl
@@ -100,7 +100,7 @@ distinguished.
           [#:property-maker prop-maker
            (-> uninitialized-wrapper-descriptor?
                (listof (cons/c struct-type-property? any/c)))
-           make-default-wrapper-properties]
+           default-wrapper-properties]
           [#:inspector inspector inspector? (current-inspector)])
          initialized-wrapper-descriptor?]
 
@@ -118,11 +118,11 @@ distinguished.
 
 @section{Wrapper Type Properties}
 
-@defproc[(make-default-wrapper-properties [descriptor wrapper-descriptor?])
+@defproc[(default-wrapper-properties [descriptor wrapper-descriptor?])
          (listof (cons/c struct-type-property? any/c))]
 
-@defproc[(make-wrapper-equal+hash [descriptor wrapper-descriptor?])
+@defproc[(default-wrapper-equal+hash [descriptor wrapper-descriptor?])
          equal+hash/c]
 
-@defproc[(make-wrapper-custom-write [descriptor wrapper-descriptor?])
+@defproc[(default-wrapper-custom-write [descriptor wrapper-descriptor?])
          custom-write-function/c]


### PR DESCRIPTION
Fixes #206 
Didn't rename only last 3 _(not provided)_ strings.

1. default-singleton-custom-write
2. default-singleton-equal+hash
3. default-singleton-object-name
