### PR TITLE
Remove immutable-set? definitions

### DIFF
--- a/private/association-list.rkt
+++ b/private/association-list.rkt
@@ -9,7 +9,7 @@
   [association-list-ref (-> association-list? any/c immutable-vector?)]
   [association-list-size (-> association-list? natural?)]
   [association-list-keys (-> association-list? multiset?)]
-  [association-list-unique-keys (-> association-list? immutable-set?)]
+  [association-list-unique-keys (-> association-list? set?)]
   [association-list-values (-> association-list? immutable-vector?)]
   [association-list-entries
    (-> association-list? (vectorof entry? #:immutable #t #:flat? #t))]
@@ -48,8 +48,6 @@
         (cons/c any/c
                 (cons/c any/c
                         (recursive-contract key-value-list/c #:flat)))))
-
-(define (immutable-set? v) (and (set? v) (not (set-mutable? v))))
 
 (define (immutable-vector-contains? vec v)
   (not (not (immutable-vector-member v vec))))

--- a/private/association-list.scrbl
+++ b/private/association-list.scrbl
@@ -88,8 +88,7 @@ key-value pairs.
    (association-list-keys (association-list 'a 1 'a 2 'a 3))
    (association-list-keys (association-list 'a 1 'a 1 'b 2 'b 2 'c 3)))}
 
-@defproc[(association-list-unique-keys [assoc association-list?])
-         immutable-set?]{
+@defproc[(association-list-unique-keys [assoc association-list?]) set?]{
  Returns a @tech/reference{set} containing the keys in @racket[assoc], without duplicates.
 
  @(examples

--- a/private/multidict.rkt
+++ b/private/multidict.rkt
@@ -14,18 +14,18 @@
   [multidict-remove-entry (-> multidict? entry? multidict?)]
   [multidict-replace-values (-> multidict? any/c set-coercible/c multidict?)]
   [multidict-size (-> multidict? natural?)]
-  [multidict-ref (-> multidict? any/c immutable-set?)]
+  [multidict-ref (-> multidict? any/c set?)]
   [multidict-keys (-> multidict? multiset?)]
   [multidict-values (-> multidict? multiset?)]
-  [multidict-unique-keys (-> multidict? immutable-set?)]
-  [multidict-unique-values (-> multidict? immutable-set?)]
+  [multidict-unique-keys (-> multidict? set?)]
+  [multidict-unique-values (-> multidict? set?)]
   [multidict-entries (-> multidict? (set/c entry? #:cmp 'equal))]
   [multidict-contains-key? (-> multidict? any/c boolean?)]
   [multidict-contains-value? (-> multidict? any/c boolean?)]
   [multidict-contains-entry? (-> multidict? entry? boolean?)]
   [multidict->hash
    (-> multidict?
-       (hash/c any/c nonempty-immutable-set? #:immutable #t #:flat? #t))]
+       (hash/c any/c nonempty-set? #:immutable #t #:flat? #t))]
   [multidict-inverse (-> multidict? multidict?)]
   [empty-multidict empty-multidict?]
   [empty-multidict? predicate/c]
@@ -59,17 +59,15 @@
                 (cons/c any/c
                         (recursive-contract key-value-list/c #:flat)))))
 
-(define (immutable-set? v) (and (set? v) (not (set-mutable? v))))
-
-(define (nonempty-immutable-set? v)
-  (and (immutable-set? v) (not (zero? (set-count v)))))
+(define (nonempty-set? v)
+  (and (set? v) (not (zero? (set-count v)))))
 
 (define set-coercible/c
-  (or/c immutable-set? multiset? (sequence/c any/c)))
+  (or/c set? multiset? (sequence/c any/c)))
 
 (define (sequence->set seq)
   (cond
-    [(immutable-set? seq) seq]
+    [(set? seq) seq]
     [(multiset? seq) (multiset-unique-elements seq)]
     [else (for/set ([v seq]) v)]))
 

--- a/private/multidict.scrbl
+++ b/private/multidict.scrbl
@@ -122,7 +122,7 @@ interface is based on a flattened collection of key-value pairs.
    (multidict-size (multidict 'a 1 'b 2 'b 3))
    (multidict-size (multidict 'a 1 'a 1 'a 1)))}
 
-@defproc[(multidict-ref [dict multidict?] [k any/c]) immutable-set?]{
+@defproc[(multidict-ref [dict multidict?] [k any/c]) set?]{
  Returns the set of values mapped by @racket[k] in @racket[dict].
 
  @(examples
@@ -163,7 +163,7 @@ interface is based on a flattened collection of key-value pairs.
                "The Hulk" 'marvel
                "Captain Marvel" 'marvel)))}
 
-@defproc[(multidict-unique-keys [dict multidict?]) immutable-set?]{
+@defproc[(multidict-unique-keys [dict multidict?]) set?]{
  Returns the set of keys in @racket[dict], ignoring duplicates.
 
  @(examples
@@ -175,7 +175,7 @@ interface is based on a flattened collection of key-value pairs.
                'vegetable 'carrot
                'vegetable 'celery)))}
 
-@defproc[(multidict-unique-values [dict multidict?]) immutable-set?]{
+@defproc[(multidict-unique-values [dict multidict?]) set?]{
  Returns the set of values in @racket[dict], ignoring duplicates.
 
   @(examples
@@ -251,7 +251,7 @@ interface is based on a flattened collection of key-value pairs.
 @section{Multidict Conversions}
 
 @defproc[(multidict->hash [dict multidict?])
-         (hash/c any/c nonempty-immutable-set? #:immutable? #t)]{
+         (hash/c any/c nonempty-set? #:immutable? #t)]{
  Converts @racket[dict] into a hash table from keys to (nonempty) sets of
  values.
 

--- a/private/multiset.rkt
+++ b/private/multiset.rkt
@@ -18,7 +18,7 @@
   [multiset-frequencies
    (-> multiset? (immutable-hash/c any/c exact-positive-integer?))]
   [multiset-size (-> multiset? natural?)]
-  [multiset-unique-elements (-> multiset? immutable-set?)]
+  [multiset-unique-elements (-> multiset? set?)]
   [multiset->list (-> multiset? list?)]
   [sequence->multiset (-> multiset-coercible-sequence/c multiset?)]
   [empty-multiset multiset?]
@@ -45,8 +45,6 @@
   (define both-flat?
     (and (flat-contract? key-contract) (flat-contract? value-contract)))
   (hash/c key-contract value-contract #:immutable #t #:flat? both-flat?))
-
-(define (immutable-set? v) (and (set? v) (not (set-mutable? v))))
 
 ;@------------------------------------------------------------------------------
 

--- a/private/multiset.scrbl
+++ b/private/multiset.scrbl
@@ -77,7 +77,7 @@ can contain duplicate elements. Elements are always compared with @racket[
    (multiset-contains? set 'orange)
    (multiset-contains? set 42))}
 
-@defproc[(multiset-unique-elements [set multiset?]) immutable-set?]{
+@defproc[(multiset-unique-elements [set multiset?]) set?]{
  Removes all duplicate elements from @racket[set], returning the resulting set.
 
  @(examples


### PR DESCRIPTION
Turns out the standard set? predicate only holds for immutable sets anyway. For some reason I thought it was for mutable and immutable sets, like how hash?, vector? , and string? work.