### PR TITLE
Add zafar-hussain to Contributors list Hacktoberfest 2019

### DIFF
--- a/private/module-binding.scrbl
+++ b/private/module-binding.scrbl
@@ -25,7 +25,7 @@
 
 @defproc[(module-binding-path [binding module-binding?]) module-path?]
 @defproc[(module-binding-phase [binding module-binding?]) phase?]
-@defproc[(module-binding-name [binding module-binding?]) symbol?]
+@defproc[(module-binding-source [binding module-binding?]) symbol?]
 
 @defproc[(module-bindings [mod module-path?]) (set/c module-binding?)]{
  Returns the set of bindings currently defined by @racket[mod], including both


### PR DESCRIPTION
re: The module-binding-path function is misdocumented #294

module-binding-name was changed to module-binding-source in private/module-binding.scrbl