### PR TITLE
Add static names utility module

### DIFF
--- a/private/association-list.rkt
+++ b/private/association-list.rkt
@@ -39,7 +39,8 @@
 
 (module+ test
   (require (submod "..")
-           rackunit))
+           rackunit
+           rebellion/private/static-name))
 
 ;@------------------------------------------------------------------------------
 
@@ -142,23 +143,23 @@
   (define assoc (association-list 'a 1 'b 2 'a 3 'c 4))
   (define alt-assoc (association-list 'a 3 'b 2 'a 1 'c 4))
 
-  (test-case "association-list-ref"
+  (test-case (name-string association-list-ref)
     (check-equal? (association-list-ref assoc 'a) (immutable-vector 1 3))
     (check-equal? (association-list-ref assoc 'b) (immutable-vector 2))
     (check-equal? (association-list-ref assoc 'd) empty-immutable-vector)
     (check-not-equal? (association-list-ref assoc 'a)
                       (association-list-ref alt-assoc 'a)))
 
-  (test-case "association-list-size"
+  (test-case (name-string association-list-size)
     (check-equal? (association-list-size assoc) 4))
 
-  (test-case "association-list-keys"
+  (test-case (name-string association-list-keys)
     (check-equal? (association-list-keys assoc) (multiset 'a 'a 'b 'c)))
 
-  (test-case "association-list-unique-keys"
+  (test-case (name-string association-list-unique-keys)
     (check-equal? (association-list-unique-keys assoc) (set 'a 'b 'c)))
 
-  (test-case "association-list-values"
+  (test-case (name-string association-list-values)
     (define vs (association-list-values assoc))
     (check-equal? (immutable-vector-length vs) 4)
     (check-true (immutable-vector-contains? vs 1))
@@ -169,7 +170,7 @@
                    (immutable-vector-index-of vs 3)))
     (check-not-equal? vs (association-list-values alt-assoc)))
 
-  (test-case "association-list-entries"
+  (test-case (name-string association-list-entries)
     (define entries (association-list-entries assoc))
     (check-equal? (immutable-vector-length entries) 4)
     (check-true (immutable-vector-contains? entries (entry 'a 1)))
@@ -180,23 +181,23 @@
                    (immutable-vector-index-of entries (entry 'a 3))))
     (check-not-equal? entries (association-list-entries alt-assoc)))
 
-  (test-case "association-list->hash"
+  (test-case (name-string association-list->hash)
     (check-equal? (association-list->hash assoc)
                   (hash 'a (immutable-vector 1 3)
                         'b (immutable-vector 2)
                         'c (immutable-vector 4))))
 
-  (test-case "association-list-contains-key?"
+  (test-case (name-string association-list-contains-key?)
     (check-true (association-list-contains-key? assoc 'a))
     (check-false (association-list-contains-key? assoc 'foo))
     (check-false (association-list-contains-key? empty-association-list 'a)))
 
-  (test-case "association-list-contains-value?"
+  (test-case (name-string association-list-contains-value?)
     (check-true (association-list-contains-value? assoc 3))
     (check-false (association-list-contains-value? assoc 1000))
     (check-false (association-list-contains-value? empty-association-list 3)))
 
-  (test-case "association-list-contains-entry?"
+  (test-case (name-string association-list-contains-entry?)
     (check-true (association-list-contains-entry? assoc (entry 'a 3)))
     (check-false (association-list-contains-entry? assoc (entry 'a 1000)))
     (check-false (association-list-contains-entry? assoc (entry 'foo 3)))

--- a/private/bit.rkt
+++ b/private/bit.rkt
@@ -10,7 +10,8 @@
 
 (module+ test
   (require (submod "..")
-           rackunit))
+           rackunit
+           rebellion/private/static-name))
 
 ;@------------------------------------------------------------------------------
 
@@ -20,9 +21,9 @@
 (define (boolean->bit b) (if b 1 0))
 
 (module+ test
-  (test-case "bit->boolean"
+  (test-case (name-string bit->boolean)
     (check-false (bit->boolean 0))
     (check-true (bit->boolean 1)))
-  (test-case "boolean->bit"
+  (test-case (name-string boolean->bit)
     (check-equal? (boolean->bit #f) 0)
     (check-equal? (boolean->bit #t) 1)))

--- a/private/bitstring.rkt
+++ b/private/bitstring.rkt
@@ -29,7 +29,8 @@
 
 (module+ test
   (require (submod "..")
-           rackunit))
+           rackunit
+           rebellion/private/static-name))
 
 ;@------------------------------------------------------------------------------
 
@@ -123,19 +124,19 @@
          (plain-bitstring padded-bytes padding)]))
 
 (module+ test
-  (test-case "bitstring"
+  (test-case (name-string bitstring)
     (for ([i (in-range 0 100)])
       (define zero-bits (apply bitstring (make-list i 0)))
       (define one-bits (apply bitstring (make-list i 1)))
       (void))
-    (test-case "roundtripping"
+    (test-case (name-string bitstring-bytes)
       (check-equal? (bitstring-bytes (bitstring 0 0 0 0 1 1 1 1
                                                 1 1 0 0 1 1 0 0
                                                 1 0 0 1))
                     (bytes (byte 0 0 0 0 1 1 1 1)
                            (byte 1 1 0 0 1 1 0 0)
                            (byte 1 0 0 1 0 0 0 0))))
-    (test-case "printing"
+    (test-case "bitstring-printed-representation"
       (check-equal? (~a (bitstring 0 1 1 0 0 1 0 1 1 1 1))
                     "#<bitstring: 0 1 1 0 0 1 0 1 1 1 1>")
       (check-equal? (~a (bitstring)) "#<bitstring:>"))))
@@ -150,13 +151,13 @@
   (byte-ref (bytes-ref bytes byte-pos) bit-pos))
 
 (module+ test
-  (test-case "bitstring-size"
+  (test-case (name-string bitstring-size)
     (check-equal? (bitstring-size (bitstring)) 0)
     (check-equal? (bitstring-size (bitstring 0)) 1)
     (check-equal? (bitstring-size (bitstring 1)) 1)
     (check-equal? (bitstring-size (bitstring 1 1 1 1 1 1 1 1)) 8)
     (check-equal? (bitstring-size (bitstring 1 1 1 1 1 1 1 1 1)) 9))
-  (test-case "bitstring-ref"
+  (test-case (name-string bitstring-ref)
     (check-equal? (bitstring-ref (bitstring 0 1) 0) 0)
     (check-equal? (bitstring-ref (bitstring 0 1) 1) 1)
     (define bits

--- a/private/byte.rkt
+++ b/private/byte.rkt
@@ -26,7 +26,8 @@
 
 (module+ test
   (require (submod "..")
-           rackunit))
+           rackunit
+           rebellion/private/static-name))
 
 ;@------------------------------------------------------------------------------
 
@@ -41,7 +42,7 @@
      h))
 
 (module+ test
-  (test-case "byte"
+  (test-case (name-string byte)
     (check-equal? (byte 0 0 0 0 0 0 0 0) 0)
     (check-equal? (byte 1 1 1 1 1 1 1 1) 255)
     (check-equal? (byte 1 0 0 0 0 0 0 0) 128)
@@ -52,7 +53,7 @@
   (quotient b (expt 2 num-bits)))
 
 (module+ test
-  (test-case "byte-drop-rightmost-bits"
+  (test-case (name-string byte-drop-rightmost-bits)
     (define f byte-drop-rightmost-bits)
     (check-equal? (f (byte 1 1 0 0 1 0 1 1) 6) (byte 0 0 0 0 0 0 1 1))
     (check-equal? (f (byte 1 1 0 0 1 0 1 1) 3) (byte 0 0 0 1 1 0 0 1))
@@ -63,7 +64,7 @@
   (modulo b (expt 2 (- 8 num-bits))))
 
 (module+ test
-  (test-case "byte-clear-leftmost-bits"
+  (test-case (name-string byte-clear-leftmost-bits)
     (define f byte-clear-leftmost-bits)
     (check-equal? (f (byte 1 1 0 0 1 0 1 1) 6) (byte 0 0 0 0 0 0 1 1))
     (check-equal? (f (byte 1 1 0 0 1 0 1 1) 3) (byte 0 0 0 0 1 0 1 1))
@@ -75,7 +76,7 @@
   (* (quotient b n) n))
 
 (module+ test
-  (test-case "byte-clear-rightmost-bits"
+  (test-case (name-string byte-clear-rightmost-bits)
     (define f byte-clear-rightmost-bits)
     (check-equal? (f (byte 1 1 0 0 1 0 1 1) 0) (byte 1 1 0 0 1 0 1 1))
     (check-equal? (f (byte 1 1 0 0 1 0 1 1) 1) (byte 1 1 0 0 1 0 1 0))
@@ -93,7 +94,7 @@
   (byte-drop-rightmost-bits (byte-clear-leftmost-bits b left-bits) right-bits))
 
 (module+ test
-  (test-case "byte-ref"
+  (test-case (name-string byte-ref)
 
     (test-case "edge-values"
       (for ([i (in-range 8)])
@@ -127,7 +128,7 @@
     (bitwise-and (byte-ref left i) (byte-ref right i))))
 
 (module+ test
-  (test-case "byte-and"
+  (test-case (name-string byte-and)
     (define test-patterns
       (list (byte 0 1 1 1 1 1 1 1)
             (byte 1 0 1 1 1 1 1 1)
@@ -150,7 +151,7 @@
     (bitwise-ior (byte-ref left i) (byte-ref right i))))
 
 (module+ test
-  (test-case "byte-or"
+  (test-case (name-string byte-or)
     (define test-patterns
       (list (byte 1 0 0 0 0 0 0 0)
             (byte 0 1 0 0 0 0 0 0)
@@ -173,7 +174,7 @@
     (bitwise-xor (byte-ref b i) 1)))
 
 (module+ test
-  (test-case "byte-not"
+  (test-case (name-string byte-not)
     (for ([x (in-range 256)])
       (check-equal? (byte-ref (byte-not x) 0) (bitwise-xor (byte-ref x 0) 1))
       (check-equal? (byte-ref (byte-not x) 1) (bitwise-xor (byte-ref x 1) 1))
@@ -191,7 +192,7 @@
     (bitwise-xor (byte-ref left i) (byte-ref right i))))
 
 (module+ test
-  (test-case "byte-xor"
+  (test-case (name-string byte-xor)
     (for ([x (in-range 256)])
       (check-equal? (byte-xor x 0) x)
       (check-equal? (byte-xor x 255) (byte-not x))
@@ -202,7 +203,7 @@
     (bitwise-xor (bitwise-and (byte-ref left i) (byte-ref right i)) 1)))
 
 (module+ test
-  (test-case "byte-nand"
+  (test-case (name-string byte-nand)
     (define test-patterns
       (list (byte 0 1 1 1 1 1 1 1)
             (byte 1 0 1 1 1 1 1 1)
@@ -225,7 +226,7 @@
     (bitwise-xor (bitwise-ior (byte-ref left i) (byte-ref right i)) 1)))
 
 (module+ test
-  (test-case "byte-nor"
+  (test-case (name-string byte-nor)
     (define test-patterns
       (list (byte 1 0 0 0 0 0 0 0)
             (byte 0 1 0 0 0 0 0 0)
@@ -248,7 +249,7 @@
     (bitwise-xor (bitwise-xor (byte-ref left i) (byte-ref right i)) 1)))
 
 (module+ test
-  (test-case "byte-xnor"
+  (test-case (name-string byte-xnor)
     (for ([x (in-range 256)])
       (check-equal? (byte-xnor x 0) (byte-not x))
       (check-equal? (byte-xnor x 255) x)
@@ -264,13 +265,13 @@
                  8))
 
 (module+ test
-  (test-case "in-byte"
+  (test-case (name-string in-byte)
     (for ([x (in-range 256)]
           #:when #t
           [b (in-byte x)]
           [i (in-range 8)])
       (check-equal? b (byte-ref x i))))
-  (test-case "into-byte"
+  (test-case (name-string into-byte)
     (check-equal? (reduce into-byte 0 0 0 0 0 0 0 0) 0)
     (check-equal? (reduce into-byte 1 1 1 1 1 1 1 1) 255)
     (check-equal? (reduce into-byte 0 0 0 0 0 0 0 1) 1)
@@ -283,7 +284,7 @@
   (for/sum ([bit (in-byte b)]) bit))
 
 (module+ test
-  (test-case "byte-hamming-weight"
+  (test-case (name-string byte-hamming-weight)
     (for ([x (in-range 256)])
       (check-equal? (byte-hamming-weight x)
                     (- 8 (byte-hamming-weight (byte-not x)))))

--- a/private/comparator.rkt
+++ b/private/comparator.rkt
@@ -25,6 +25,7 @@
 
 (require rebellion/base/immutable-string
          rebellion/base/symbol
+         rebellion/private/static-name
          rebellion/type/reference
          rebellion/type/singleton)
 
@@ -59,28 +60,29 @@
   (define (wrapped-func left right) (func right left))
   (make-comparator wrapped-func))
 
-(define real<=>
+(define/name real<=>
   (make-comparator
    (λ (x y) (cond [(< x y) lesser] [(= x y) equivalent] [else greater]))
-   #:name 'real<=>))
+   #:name enclosing-variable-name))
 
-(define string<=>
+(define/name string<=>
   (make-comparator
    (λ (s1 s2)
      (cond [(immutable-string<? s1 s2) lesser]
            [(equal? s1 s2) equivalent]
-           [else greater]))))
+           [else greater]))
+   #:name enclosing-variable-name))
 
 (module+ test
-  (test-case "real<=>"
+  (test-case (name-string real<=>)
     (check-equal? (compare real<=> 4 5.2) lesser)
     (check-equal? (compare real<=> 0 -7) greater)
     (check-equal? (compare real<=> 3 3) equivalent))
-  (test-case "string<=>"
+  (test-case (name-string string<=>)
     (check-equal? (compare string<=> "apple" "banana") lesser)
     (check-equal? (compare string<=> "apple" "aardvark") greater)
     (check-equal? (compare string<=> "apple" "apple") equivalent))
-  (test-case "comparator-reverse"
+  (test-case (name-string comparator-reverse)
     (define reversed (comparator-reverse real<=>))
     (check-equal? (compare reversed 1 2) greater)
     (check-equal? (compare reversed 2 1) lesser)

--- a/private/entry.rkt
+++ b/private/entry.rkt
@@ -22,6 +22,7 @@
          racket/set
          rebellion/base/variant
          rebellion/collection/list
+         rebellion/private/static-name
          rebellion/streaming/reducer
          rebellion/streaming/transducer
          rebellion/type/record
@@ -192,7 +193,7 @@
                   #:encounter-ordered-keys keys
                   #:size (list-size keys)))
 
-(define (grouping value-reducer)
+(define/name (grouping value-reducer)
   (define start-value (reducer-starter value-reducer))
   (define consume-value (reducer-consumer value-reducer))
   (define finish-value (reducer-finisher value-reducer))
@@ -234,10 +235,11 @@
          [(zero? (closing-groups-size next-g)) (variant #:finish #f)]
          [else (variant #:half-closed-emit next-g)]))
      (half-closed-emission next-state (entry next-key next-value)))
-   #:finisher void))
+   #:finisher void
+   #:name enclosing-function-name))
 
 (module+ test
-  (test-case "grouping"
+  (test-case (name-string grouping)
     (check-equal? (transduce (list (entry 'a 1)
                                    (entry 'a 2)
                                    (entry 'a 3)

--- a/private/equivalence-relation.rkt
+++ b/private/equivalence-relation.rkt
@@ -19,6 +19,7 @@
    (-> equivalence-relation? (-> any/c any/c) equivalence-relation?)]))
 
 (require rebellion/base/symbol
+         rebellion/private/static-name
          rebellion/type/reference)
 
 (module+ test
@@ -36,28 +37,29 @@
 (define (equivalence-relation-holds? relation x y)
   ((equivalence-relation-function relation) x y))
 
-(define natural-equality
-  (make-equivalence-relation equal? #:name 'natural-equality))
+(define/name natural-equality
+  (make-equivalence-relation equal? #:name enclosing-variable-name))
 
-(define object-identity-equality
-  (make-equivalence-relation eq? #:name 'object-identity-equality))
+(define/name object-identity-equality
+  (make-equivalence-relation eq? #:name enclosing-variable-name))
 
-(define numeric-equality (make-equivalence-relation = #:name 'numeric-equality))
+(define/name numeric-equality
+  (make-equivalence-relation = #:name enclosing-variable-name))
 
 (module+ test
   (struct foo (value) #:transparent)
   (define x (foo 1))
   (define y (foo 1))
   (define z (foo 2))
-  (test-case "natural-equality"
+  (test-case (name-string natural-equality)
     (check-true (equivalence-relation-holds? natural-equality x y))
     (check-false (equivalence-relation-holds? natural-equality x z))
     (check-false (equivalence-relation-holds? natural-equality 1 1.0))
     (check-true (equivalence-relation-holds? natural-equality +nan.0 +nan.0)))
-  (test-case "object-identity-equality"
+  (test-case (name-string object-identity-equality)
     (check-true (equivalence-relation-holds? object-identity-equality x x))
     (check-false (equivalence-relation-holds? object-identity-equality x y)))
-  (test-case "numeric-equality"
+  (test-case (name-string numeric-equality)
     (check-true (equivalence-relation-holds? numeric-equality 1 1.0))
     (check-true (equivalence-relation-holds? numeric-equality 0.0 -0.0))
     (check-false (equivalence-relation-holds? numeric-equality 1 2))
@@ -68,7 +70,7 @@
   (make-equivalence-relation (λ (x y) (original (f x) (f y)))))
 
 (module+ test
-  (test-case "equivalence-relation-map"
+  (test-case (name-string equivalence-relation-map)
     (define rel
       (equivalence-relation-map natural-equality string-length))
     (check-true (equivalence-relation-holds? rel "foo" "bar"))

--- a/private/static-name.rkt
+++ b/private/static-name.rkt
@@ -1,0 +1,109 @@
+#lang racket/base
+
+;; This module provides utilities for working with static names. A static name
+;; is a symbol or string that is derived from a bound identifier. Static names
+;; are primarily used in error messages in order to identify pieces of code
+;; relevant to the error. Static names are always derived at compile-time.
+;;
+;; Using static names is similar to using the quote macro, but whereas quoting
+;; allows constructing symbols from arbitrary identifiers, static names can only
+;; be constructed from *bound* identifiers. This ensures that typos in names
+;; used within error messages cause compile-time errors instead of silently
+;; incorrect message text. Furthermore, constructing a static name counts as a
+;; *disappeared use* of the identifier, meaning that DrRacket will draw binding
+;; arrows to it and DrRacket's identifier-rename operation will work correctly.
+;;
+;; This module is private to Rebellion for the time being. After using it
+;; internally and getting a better sense of how the API should look, we may
+;; consider exposing it publicly (with actual Scribble docs).
+
+(provide name ;; Like quote, but the given identifier must be bound
+         
+         name-string ;; Like name, but produces a string instead of a symbol
+
+         ;; A variable-like macro that is set by define/name.
+         enclosing-function-name
+
+         ;; Like define, but sets enclosing-function-name when used for function
+         ;; definitions. Variable definitions such as (define/name foo 42) are
+         ;; allowed, but they don't change enclosing-function-name.
+         ;;
+         ;; Example:
+         ;;
+         ;; (define/name (check-even n)
+         ;;   (unless (even? n)
+         ;;     (raise-argument-error enclosing-function-name
+         ;;                           (name-string even?)
+         ;;                           n)))
+         define/name)
+
+(require (for-syntax racket/base
+                     syntax/parse/lib/function-header)
+         racket/splicing
+         racket/stxparam
+         syntax/parse/define)
+
+(module+ test
+  (require (submod "..")
+           rackunit))
+
+;@------------------------------------------------------------------------------
+
+(begin-for-syntax
+  ;; The function-header syntax class really should provide a .name attribute
+  ;; that recursively traverses into subheaders, but as of Racket 7.4 it
+  ;; doesn't. So we have to make our own version of function-header.
+  (define-syntax-class function-header-with-recursive-name
+    #:attributes (function-name)
+    (pattern (function-name:id . args:formals))
+    (pattern (header:function-header-with-recursive-name . args:formals)
+      #:with function-name #'header.function-name)))
+
+(define-syntax (raise-enclosing-function-name-unbound-error stx)
+  (raise-syntax-error #f "not bound by any enclosing definition forms" stx))
+
+(define-rename-transformer-parameter enclosing-function-name
+  (make-rename-transformer #'raise-enclosing-function-name-unbound-error))
+
+(begin-for-syntax
+  (define (check-name-has-binding! id-stx context-stx)
+    (unless (identifier-binding id-stx)
+      (raise-syntax-error #f "named identifier not bound" context-stx id-stx))
+    (syntax-parse-state-cons! 'literals id-stx)))
+
+(define-simple-macro (name/derived id:id #:context context)
+  #:do [(check-name-has-binding! #'id #'context)]
+  (quote id))
+
+(define-simple-macro (name id:id)
+  #:with context this-syntax
+  (#%expression (name/derived id #:context context)))
+
+(define-simple-macro (name-string/derived id:id #:context context)
+  #:do [(check-name-has-binding! #'id #'context)]
+  #:with literal-string (string->immutable-string
+                         (symbol->string (syntax-e #'id)))
+  (quote literal-string))
+
+(define-simple-macro (name-string id:id)
+  #:with context this-syntax
+  (#%expression (name-string/derived id #:context context)))
+
+(define-simple-macro
+  (define/name
+    (~or id:id header:function-header-with-recursive-name)
+    body ...)
+  (~? (define id body ...)
+      (splicing-let ([function-name (quote header.function-name)])
+        (splicing-syntax-parameterize
+            ([enclosing-function-name
+              (make-rename-transformer #'function-name)])
+          (define header body ...)))))
+
+(module+ test
+  (test-case (name-string define/name)
+    (define/name (check-even n)
+      (unless (even? n)
+        (raise-argument-error enclosing-function-name (name-string even?) n)))
+    (check-exn #rx"check-even:" (λ () (check-even 3)))
+    (check-exn #rx"even\\?" (λ () (check-even 3)))))

--- a/private/table.rkt
+++ b/private/table.rkt
@@ -27,6 +27,7 @@
          rebellion/collection/keyset
          rebellion/collection/record
          rebellion/private/markup
+         rebellion/private/static-name
          rebellion/streaming/reducer
          rebellion/type/record
          syntax/parse/define)
@@ -50,14 +51,14 @@
   (define size-field (keyset-index-of fields '#:size))
   (define custom-write
     (make-constructor-style-printer
-     (λ (_) 'table)
+     (λ (_) (name table))
      (λ (this)
        (define vectors (accessor this backing-column-vectors-field))
        (define size (accessor this size-field))
        (define column-names (record-keywords vectors))
        (define columns-markup
          (constructor-call-markup
-          #:type-name 'columns
+          #:type-name (name columns)
           #:subexpressions
           (for/list ([k (in-keyset column-names)]) (keyword-markup k))))
        (define rows-markup
@@ -66,7 +67,7 @@
              (for/list ([k (in-keyset column-names)])
                (table-ref this pos k)))
            (constructor-call-markup
-            #:type-name 'row
+            #:type-name (name row)
             #:subexpressions row-values)))
        (stream-cons columns-markup rows-markup))))
   (list (cons prop:custom-write custom-write)
@@ -164,7 +165,7 @@
         [else
          (unless (equal? columns (record-keywords record))
            (define msg "record contains different keys than previous records")
-           (raise-arguments-error 'into-table
+           (raise-arguments-error (name into-table)
                                   msg
                                   "record" record
                                   "previous-keys" columns))
@@ -189,11 +190,11 @@
   (define columns-record (build-record build columns))
   (constructor:table #:backing-column-vectors columns-record #:size size))
 
-(define into-table
+(define/name into-table
   (make-effectful-fold-reducer table-builder-add
                                empty-table-builder
                                build-table
-                               #:name 'into-table))
+                               #:name enclosing-variable-name))
 
 (define-syntaxes (for/table for*/table)
   (make-reducer-based-for-comprehensions #'into-table))

--- a/private/transducer-batching.rkt
+++ b/private/transducer-batching.rkt
@@ -7,6 +7,7 @@
   [batching (-> reducer? transducer?)]))
 
 (require rebellion/base/variant
+         rebellion/private/static-name
          rebellion/streaming/reducer
          rebellion/streaming/transducer/base
          rebellion/type/singleton
@@ -17,7 +18,7 @@
 (define-singleton-type unstarted-batch-placeholder)
 (define-tuple-type batch (state))
 
-(define (batching batch-reducer)
+(define/name (batching batch-reducer)
   (define batch-starter (reducer-starter batch-reducer))
   (define batch-consumer (reducer-consumer batch-reducer))
   (define batch-finisher (reducer-finisher batch-reducer))
@@ -25,7 +26,7 @@
   (define (start-new-batch)
     (define init-state (batch-starter))
     (unless (variant-tagged-as? init-state '#:consume)
-      (raise-arguments-error 'batching
+      (raise-arguments-error enclosing-function-name
                              "batch reducer must consume at least one value"
                              "batch reducer" batch-reducer
                              "batch start state" init-state))
@@ -58,4 +59,4 @@
    #:half-closer half-close
    #:half-closed-emitter half-closed-emit
    #:finisher void
-   #:name 'batching))
+   #:name enclosing-function-name))


### PR DESCRIPTION
Inspired by the `define/who` macro [buried inside Racket's implementation](https://github.com/racket/racket/blob/master/racket/src/cs/rumble/check.ss), this pull request adds:

1. A `(name foo)` macro which is exactly like `(quote foo)` except it requires that `foo` is bound, and it counts as a disappeared use of `foo` (so DrRacket binding arrows and renaming works)

2. A `(name-string foo)` macro that's like `(name foo)` but produces a string instead of a symbol.

3. A `define/name` macro combined with two syntax parameters, `enclosing-function-name` and `enclosing-variable-name`, that cooperate together to implicitly get the name of the surrounding function or variable definition.

The goal is to make sure DrRacket's identifier renaming feature works correctly more often. See the `private/static-name.rkt` module for details.

@samdphillips, do you think this is a good idea?