### PR TITLE
Implement Range API (#315)

### DIFF
--- a/private/range.rkt
+++ b/private/range.rkt
@@ -1,14 +1,24 @@
 #lang racket/base
 
-(provide (rename-out [range/macro range])
-         range?
-         range/lower
-         range/lower?
-         range/lower-incl
-         range/upper
-         range/upper?
-         range/upper-incl
-         range/contains)
+(require racket/contract/base)
+
+(provide
+ (rename-out [range/macro range])
+ (contract-out
+  [range/create (-> (or/c option? null?)
+                    (or/c boolean? null?)
+                    (or/c option? null?)
+                    (or/c boolean? null?)
+                    (or/c comparator? null?)
+                    range?)]
+  [range? predicate/c]
+  [range/lower? (-> range? boolean?)]
+  [range/lower (-> range? any/c)]
+  [range/lower-incl? (-> range? boolean?)]
+  [range/upper? (-> range? boolean?)]
+  [range/upper (-> range? any/c)]
+  [range/upper-incl? (-> range? boolean?)]
+  [range/contains? (-> range? any/c boolean?)]))
 
 (require (for-syntax racket/base
                      syntax/parse)
@@ -61,17 +71,17 @@
   (present? (range-lower-val range)))
 (define (range/lower range)
   (present-value (range-lower-val range)))
-(define (range/lower-incl range)
+(define (range/lower-incl? range)
   (and (range/lower? range) (range-lower-incl range)))
 
 (define (range/upper? range)
   (present? (range-upper-val range)))
 (define (range/upper range)
   (present-value (range-upper-val range)))
-(define (range/upper-incl range)
+(define (range/upper-incl? range)
   (and (range/upper? range) (range-upper-incl range)))
 
-(define (range/contains range value)
+(define (range/contains? range value)
   (define comparator (range-comparator range))
   (and (option-case (range-lower-val range)
          #:present (λ (lower)

--- a/private/range.rkt
+++ b/private/range.rkt
@@ -20,16 +20,24 @@
     (pattern (~seq [v:expr i:boolean]))
     (pattern (~seq val:value)
              #:with v #'val.v
-             #:with i #'null)))
+             #:with i #'null))
+  (define-splicing-syntax-class bounds
+    #:attributes(l.v l.i u.v u.i)
+    (pattern (~seq (~optional l:bound
+                              #:defaults([l.v #'0] [l.i #'null]))
+                   u:bound))
+    (pattern (~seq (~or (~seq #:incl (~bind [l.i #'#t]))
+                        (~seq #:excl (~bind [l.i #'#f])))
+                   (~optional (~seq l:value
+                                    (~or (~seq #:incl (~bind [u.i #'#t]))
+                                         (~seq #:excl (~bind [u.i #'#f]))
+                                         (~seq (~bind [u.i #'l.i]))))
+                              #:defaults([l.v #'0] [u.i #'l.i]))
+                   u:value))))
 
 (define-syntax (range/macro stx)
   (syntax-parse stx
-    [(_ u:bound) #'(range/create 0 null u.v u.i)]
-    [(_ l:bound u:bound) #'(range/create l.v l.i u.v u.i)]
-    [(_ #:incl l:value u:value) #'(range/create l.v #t u.v #t)]
-    [(_ #:excl l:value u:value) #'(range/create l.v #f u.v #f)]
-    [(_ #:incl l:value #:excl u:value) #'(range/create l.v #t u.v #f)]
-    [(_ #:excl l:value #:incl u:value) #'(range/create l.v #f u.v #t)]))
+    [(_ b:bounds) #'(range/create b.l.v b.l.i b.u.v b.u.i)]))
 
 (struct range (lower upper))
 (struct bound (value incl))

--- a/private/range.rkt
+++ b/private/range.rkt
@@ -1,0 +1,72 @@
+#lang racket/base
+
+(provide (rename-out [range/macro range])
+         range?
+         range/lower
+         range/lower?
+         range/lower-incl
+         range/upper
+         range/upper?
+         range/upper-incl
+         range/contains)
+
+(require (for-syntax racket/base syntax/parse))
+(begin-for-syntax
+  (define-splicing-syntax-class value
+    (pattern (~seq (~datum *))
+             #:with v #'null)
+    (pattern (~seq v:expr)))
+  (define-splicing-syntax-class bound
+    (pattern (~seq [v:expr i:boolean]))
+    (pattern (~seq val:value)
+             #:with v #'val.v
+             #:with i #'null)))
+
+(define-syntax (range/macro stx)
+  (syntax-parse stx
+    [(_ u:bound) #'(range/create 0 null u.v u.i)]
+    [(_ l:bound u:bound) #'(range/create l.v l.i u.v u.i)]
+    [(_ #:incl l:value u:value) #'(range/create l.v #t u.v #t)]
+    [(_ #:excl l:value u:value) #'(range/create l.v #f u.v #f)]
+    [(_ #:incl l:value #:excl u:value) #'(range/create l.v #t u.v #f)]
+    [(_ #:excl l:value #:incl u:value) #'(range/create l.v #f u.v #t)]))
+
+(struct range (lower upper))
+(struct bound (value incl))
+(define unbounded (bound null #f))
+
+(define (range/create lower lower-incl upper upper-incl)
+  (range (cond
+           [(null? lower) unbounded]
+           [(null? lower-incl) (bound lower #t)]
+           [else (bound lower lower-incl)])
+         (cond
+           [(null? upper) unbounded]
+           [(null? upper-incl) (bound upper #f)]
+           [else (bound upper upper-incl)])))
+
+(define (range/lower? range)
+  (not (eq? (range-lower range) unbounded)))
+(define (range/lower range)
+  (bound-value (range-lower range)))
+(define (range/lower-incl range)
+  (bound-incl (range-lower range)))
+
+(define (range/upper? range)
+  (not (eq? (range-upper range) unbounded)))
+(define (range/upper range)
+  (bound-value (range-upper range)))
+(define (range/upper-incl range)
+  (bound-incl (range-upper range)))
+
+(define (range/contains range value)
+  (and (let ([lower (range-lower range)])
+         (cond
+           [(eq? lower unbounded) #t]
+           [(bound-incl lower) (<= (bound-value lower) value)]
+           [else (< (bound-value lower) value)]))
+       (let ([upper (range-upper range)])
+         (cond
+           [(eq? upper unbounded) #t]
+           [(bound-incl upper) (>= (bound-value upper) value)]
+           [else (>= (bound-value upper) value)]))))


### PR DESCRIPTION
This PR implements the range API discussed in #315.

## API Examples

### Creation

```racket
;Upper bound
(range 10); [0, 10)
(range [10 #t]); [0, 10]

;Lower & upper bound
(range 0 10); [0, 10)
(range 0 [10 #t]); [0, 10]
(range [0 #f] [10 #t]); (0, 10]

;Using * for unbounded
(range *); [0, *)
(range 0 *); [0, *)
(range [0 #f] *); (0, *)
(range * 0); (*, 0)
(range * *); (*, *)

;Using inclusivity keywords
(range #:incl 0 10); [0, 10]
(range #:excl 0 10); (0, 10)
(range #:incl 0 #:excl 10); [0, 10)
(range #:excl 0 #:incl 10); (0, 10]
(range #:incl 0 *); [0, *) //still exclusive for unbounded
```

### API Functions

```racket
(define positive (range 1 *)); [1, *)

(range? positive); #t

(range/lower? positive); #t
(range/lower positive); 1
(range/lower-incl positive); #t

(range/upper? positive); #f
(range/upper positive); null, aka '()
(range/upper-incl positive); #f

(range/contains positive 0); #f
(range/contains positive 1); #t
(range/contains positive +inf.0); #t
(range/contains positive -inf.0); #f
```

## Implementation

The implementation is pretty straightforward. It uses a range struct which contains a lower and upper bound, which is itself a struct having a value and an inclusivity. There is also an unbounded bound which is represented by `(bound null #f)`.

### Creation

The process to create ranges is really the source of complexity here. This makes use of a macro to allow `*` to be used to define a bound as unbounded. This has three main components:

 1. Syntax classes for bound and value:
    - A bound consists of both a value and an inclusivity. It is specified as a pair as in `[value incl]`, or as only a value which will use the default inclusivity (closed-open).
    - A value is either an expression or the symbol `*` (representing unbounded).
 2. Macro for processing syntax and rewriting, in three forms:
     - Range defined with only a upper bound, which uses a lower bound of `0`.
     - Range with both lower and upper bounds
     - Range specifying values as inclusive or exclusive using keywords, as in `#:incl 1 7` or `#:excl 0 #:incl 7` (both being the same range). The use of a macro here ensures keywords are in the correct spots and prevents the issues we saw with a standard keyword function.
 3. Function for creating the range and applying defaults:
     - This simply takes the bounds extracted from the macro and applies the necessary defaults, with null values turning into unbounded bounds and null inclusivity becoming the proper default under closed-open ranges.

## TODO

From here, there are couple of core pieces which still need to be done (in a rough order):
 - [ ] Finalize the base API
 - [ ] Add iterations & sequence functions
 - [ ] Canonical ranges & domains
 - [ ] RangeSet implementation

Additionally, I would greatly appreciate some guidance on putting together documentation, tests, and contracts - I haven't worked with these before in Racket and aren't sure what the best practices are. Any other feedback on the design/implementation would be welcome too!