### PR TITLE
Add basic range API

### DIFF
--- a/base/range.rkt
+++ b/base/range.rkt
@@ -1,0 +1,2 @@
+#lang reprovide
+rebellion/private/range

--- a/private/base.scrbl
+++ b/private/base.scrbl
@@ -14,3 +14,4 @@
 @include-section[(lib "rebellion/private/variant.scrbl")]
 @include-section[(lib "rebellion/private/equivalence-relation.scrbl")]
 @include-section[(lib "rebellion/private/comparator.scrbl")]
+@include-section[(lib "rebellion/private/range.scrbl")]

--- a/private/range.rkt
+++ b/private/range.rkt
@@ -1,0 +1,271 @@
+#lang racket/base
+
+(require racket/contract/base)
+
+(provide
+ (contract-out
+  [range? predicate/c]
+
+  [range
+   (->i #:chaperone
+        ([lower-bound (or/c range-bound? unbounded?)]
+         [upper-bound (or/c range-bound? unbounded?)])
+        (#:comparator [cmp comparator?])
+
+        #:pre/name (lower-bound upper-bound cmp)
+        "lower endpoint must be less than or equal to upper endpoint"
+        (cond
+          [(unbounded? lower-bound) #t]
+          [(unbounded? upper-bound) #t]
+          [else
+           (define lower (range-bound-endpoint lower-bound))
+           (define upper (range-bound-endpoint upper-bound))
+           (not (equal? (compare (default-real<=> cmp) lower upper) greater))])
+
+        #:pre/name (lower-bound upper-bound)
+        "equal endpoints cannot both be exclusive"
+        (not (and (exclusive-bound? lower-bound)
+                  (exclusive-bound? upper-bound)
+                  (equal? (exclusive-bound-endpoint lower-bound)
+                          (exclusive-bound-endpoint upper-bound))))
+
+        [_ range?])]
+  
+  [closed-range
+   (->i #:chaperone
+        ([lower any/c]
+         [upper any/c])
+        (#:comparator [cmp comparator?])
+
+        #:pre/name (lower upper cmp)
+        "lower endpoint must be less than or equal to upper endpoint"
+        (not (equal? (compare (default-real<=> cmp) lower upper) greater))
+
+        [_ range?])]
+
+  [open-range
+   (->i #:chaperone
+        ([lower any/c]
+         [upper any/c])
+        (#:comparator [cmp comparator?])
+
+        #:pre/name (lower upper cmp)
+        "lower endpoint must be less than upper endpoint"
+        (equal? (compare (default-real<=> cmp) lower upper) lesser)
+
+        [_ range?])]
+
+  [closed-open-range
+   (->i #:chaperone
+        ([lower any/c]
+         [upper any/c])
+        (#:comparator [cmp comparator?])
+
+        #:pre/name (lower upper cmp)
+        "lower endpoint must be less than or equal to upper endpoint"
+        (not (equal? (compare (default-real<=> cmp) lower upper) greater))
+
+        [_ range?])]
+
+  [open-closed-range
+   (->i #:chaperone
+        ([lower any/c]
+         [upper any/c])
+        (#:comparator [cmp comparator?])
+
+        #:pre/name (lower upper cmp)
+        "lower endpoint must be less than or equal to upper endpoint"
+        (not (equal? (compare (default-real<=> cmp) lower upper) greater))
+
+        [_ range?])]
+
+  [at-least unbounded-range-constructor/c]
+  [at-most unbounded-range-constructor/c]
+  [less-than unbounded-range-constructor/c]
+  [greater-than unbounded-range-constructor/c]
+  [range-contains? (-> range? any/c boolean?)]
+  [range-lower-bound (-> range? (or/c range-bound? unbounded?))]
+  [range-upper-bound (-> range? (or/c range-bound? unbounded?))]
+  [range-comparator (-> range? comparator?)]
+  [unbounded? predicate/c]
+  [unbounded unbounded?]
+  [range-bound-type? predicate/c]
+  [inclusive range-bound-type?]
+  [exclusive range-bound-type?]
+  [range-bound? predicate/c]
+  [range-bound-endpoint (-> range-bound? any/c)]
+  [range-bound-type (-> range-bound? range-bound-type?)]
+  [inclusive-bound (-> any/c range-bound?)]
+  [exclusive-bound (-> any/c range-bound?)]))
+
+(require rebellion/base/comparator
+         rebellion/type/singleton
+         rebellion/type/tuple)
+
+(module+ test
+  (require (submod "..")
+           rackunit
+           rebellion/private/static-name))
+
+;@------------------------------------------------------------------------------
+;; Data model
+
+(define-tuple-type range (lower-bound upper-bound comparator)
+  #:constructor-name constructor:range)
+
+(define-singleton-type unbounded)
+
+(define-singleton-type inclusive)
+(define-singleton-type exclusive)
+
+(define-tuple-type inclusive-bound (endpoint))
+(define-tuple-type exclusive-bound (endpoint))
+
+(define (range-bound? v)
+  (or (inclusive-bound? v) (exclusive-bound? v)))
+
+(define (range-bound-type? v)
+  (or (inclusive? v) (exclusive? v)))
+
+(define (range-bound-type bound)
+  (if (inclusive-bound? bound) inclusive exclusive))
+
+(define (range-bound-endpoint bound)
+  (if (inclusive-bound? bound)
+      (inclusive-bound-endpoint bound)
+      (exclusive-bound-endpoint bound)))
+
+(define (range lower-bound upper-bound #:comparator [comparator real<=>])
+  (constructor:range lower-bound upper-bound comparator))
+
+(define (range-contains? rng v)
+  (define lower (range-lower-bound rng))
+  (define upper (range-upper-bound rng))
+  (define cmp (range-comparator rng))
+  (define within-lower-bound?
+    (cond
+      [(unbounded? lower) #t]
+      [else
+       (define result (compare cmp (range-bound-endpoint lower) v))
+       (if (exclusive-bound? lower)
+           (equal? result lesser)
+           (not (equal? result greater)))]))
+  (define within-upper-bound?
+    (cond
+      [(unbounded? upper) #t]
+      [else
+       (define result (compare cmp v (range-bound-endpoint upper)))
+       (if (exclusive-bound? upper)
+           (equal? result lesser)
+           (not (equal? result greater)))]))
+  (and within-lower-bound? within-upper-bound?))
+
+;@------------------------------------------------------------------------------
+;; Smart constructors
+
+(define ((range-factory lower-bound-maker upper-bound-maker)
+         lower-endpoint upper-endpoint #:comparator [comparator real<=>])
+  (range (lower-bound-maker lower-endpoint) (upper-bound-maker upper-endpoint)
+         #:comparator comparator))
+
+(define closed-range (range-factory inclusive-bound inclusive-bound))
+(define open-range (range-factory exclusive-bound exclusive-bound))
+(define closed-open-range (range-factory inclusive-bound exclusive-bound))
+(define open-closed-range (range-factory exclusive-bound inclusive-bound))
+
+(define (at-least endpoint #:comparator [comparator real<=>])
+  (range (inclusive-bound endpoint) unbounded #:comparator comparator))
+
+(define (at-most endpoint #:comparator [comparator real<=>])
+  (range unbounded (inclusive-bound endpoint) #:comparator comparator))
+
+(define (greater-than endpoint #:comparator [comparator real<=>])
+  (range (exclusive-bound endpoint) unbounded #:comparator comparator))
+
+(define (less-than endpoint #:comparator [comparator real<=>])
+  (range unbounded (exclusive-bound endpoint) #:comparator comparator))
+
+(module+ test
+  (test-case (name-string range)
+    (check-exn exn:fail:contract?
+               (λ () (range (inclusive-bound 5) (inclusive-bound 2))))
+    (check-exn exn:fail:contract?
+               (λ () (range (inclusive-bound 5) (exclusive-bound 2))))
+    (check-exn exn:fail:contract?
+               (λ () (range (exclusive-bound 5) (inclusive-bound 2))))
+    (check-exn exn:fail:contract?
+               (λ () (range (exclusive-bound 5) (exclusive-bound 2))))
+    (check-exn exn:fail:contract?
+               (λ () (range (exclusive-bound 3) (exclusive-bound 3)))))
+  
+  (test-case (name-string closed-range)
+    (define rng (closed-range 2 4))
+    (check-false (range-contains? rng 1))
+    (check-true (range-contains? rng 2))
+    (check-true (range-contains? rng 3))
+    (check-true (range-contains? rng 4))
+    (check-false (range-contains? rng 5))
+    (check-exn exn:fail:contract? (λ () (closed-range 4 2)))
+    (check-true (range-contains? (closed-range 3 3) 3)))
+
+  (test-case (name-string open-range)
+    (define rng (open-range 2 4))
+    (check-false (range-contains? rng 1))
+    (check-false (range-contains? rng 2))
+    (check-true (range-contains? rng 3))
+    (check-false (range-contains? rng 4))
+    (check-false (range-contains? rng 5))
+    (check-exn exn:fail:contract? (λ () (open-range 4 2)))
+    (check-exn exn:fail:contract? (λ () (open-range 3 3))))
+
+  (test-case (name-string closed-open-range)
+    (define rng (closed-open-range 2 4))
+    (check-false (range-contains? rng 1))
+    (check-true (range-contains? rng 2))
+    (check-true (range-contains? rng 3))
+    (check-false (range-contains? rng 4))
+    (check-false (range-contains? rng 5))
+    (check-exn exn:fail:contract? (λ () (closed-open-range 4 2)))
+    (check-false (range-contains? (closed-open-range 3 3) 3)))
+
+  (test-case (name-string open-closed-range)
+    (define rng (open-closed-range 2 4))
+    (check-false (range-contains? rng 1))
+    (check-false (range-contains? rng 2))
+    (check-true (range-contains? rng 3))
+    (check-true (range-contains? rng 4))
+    (check-false (range-contains? rng 5))
+    (check-exn exn:fail:contract? (λ () (open-closed-range 4 2)))
+    (check-false (range-contains? (open-closed-range 3 3) 3)))
+
+  (test-case (name-string at-least)
+    (define rng (at-least 2))
+    (check-false (range-contains? rng 1))
+    (check-true (range-contains? rng 2))
+    (check-true (range-contains? rng 3)))
+
+  (test-case (name-string at-most)
+    (define rng (at-most 2))
+    (check-true (range-contains? rng 1))
+    (check-true (range-contains? rng 2))
+    (check-false (range-contains? rng 3)))
+
+  (test-case (name-string greater-than)
+    (define rng (greater-than 2))
+    (check-false (range-contains? rng 1))
+    (check-false (range-contains? rng 2))
+    (check-true (range-contains? rng 3)))
+
+  (test-case (name-string less-than)
+    (define rng (less-than 2))
+    (check-true (range-contains? rng 1))
+    (check-false (range-contains? rng 2))
+    (check-false (range-contains? rng 3))))
+
+;@------------------------------------------------------------------------------
+;; Contract helpers
+
+(define (default-real<=> v) (if (unsupplied-arg? v) real<=> v))
+
+(define unbounded-range-constructor/c
+  (->* (any/c) (#:comparator comparator?) range?))

--- a/private/range.rkt
+++ b/private/range.rkt
@@ -79,10 +79,11 @@
 
         [_ range?])]
 
-  [at-least unbounded-range-constructor/c]
-  [at-most unbounded-range-constructor/c]
-  [less-than unbounded-range-constructor/c]
-  [greater-than unbounded-range-constructor/c]
+  [at-least single-endpoint-range-constructor/c]
+  [at-most single-endpoint-range-constructor/c]
+  [less-than single-endpoint-range-constructor/c]
+  [greater-than single-endpoint-range-constructor/c]
+  [singleton-range single-endpoint-range-constructor/c]
   [range-contains? (-> range? any/c boolean?)]
   [range-lower-bound (-> range? (or/c range-bound? unbounded?))]
   [range-upper-bound (-> range? (or/c range-bound? unbounded?))]
@@ -185,6 +186,10 @@
 (define (less-than endpoint #:comparator [comparator real<=>])
   (range unbounded (exclusive-bound endpoint) #:comparator comparator))
 
+(define (singleton-range endpoint #:comparator [comparator real<=>])
+  (define bound (inclusive-bound endpoint))
+  (range bound bound #:comparator comparator))
+
 (module+ test
   (test-case (name-string range)
     (check-exn exn:fail:contract?
@@ -260,12 +265,18 @@
     (define rng (less-than 2))
     (check-true (range-contains? rng 1))
     (check-false (range-contains? rng 2))
-    (check-false (range-contains? rng 3))))
+    (check-false (range-contains? rng 3)))
+
+  (test-case (name-string singleton-range)
+    (define rng (singleton-range 42))
+    (check-true (range-contains? rng 42))
+    (check-false (range-contains? rng 41))
+    (check-false (range-contains? rng 43))))
 
 ;@------------------------------------------------------------------------------
 ;; Contract helpers
 
 (define (default-real<=> v) (if (unsupplied-arg? v) real<=> v))
 
-(define unbounded-range-constructor/c
+(define single-endpoint-range-constructor/c
   (->* (any/c) (#:comparator comparator?) range?))

--- a/private/range.scrbl
+++ b/private/range.scrbl
@@ -249,3 +249,20 @@ indication of whether the bound is inclusive or exclusive.
    (range-contains? (closed-range 3 7) 10)
    (range-contains? (greater-than "apple" #:comparator string<=>) "banana")
    (range-contains? (greater-than "apple" #:comparator string<=>) "aardvark"))}
+
+@defproc[(range-encloses? [range range?] [other-range range?]) boolean?]{
+ Determines whether or not @racket[range] @tech{encloses} @racket[other-range].
+ One range @deftech{encloses} another range when the first range contains every
+ value contained by the second. Both ranges must use the same @tech{comparator},
+ or else a contract violation is raised. Every range encloses itself, and empty
+ ranges never enclose nonempty ranges.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (range-encloses? (open-range 2 8) (closed-range 4 6))
+   (range-encloses? (open-range 2 8) (closed-range 2 6))
+   (range-encloses? (open-range 2 8) (at-least 5))
+   (range-encloses? (greater-than 2) (at-least 5))
+   (eval:error
+    (range-encloses? (greater-than 2)
+                     (greater-than "apple" #:comparator string<=>))))}

--- a/private/range.scrbl
+++ b/private/range.scrbl
@@ -238,8 +238,8 @@ indication of whether the bound is inclusive or exclusive.
 
 @section{Querying Ranges}
 
-@defproc[(range-contains? [rng range?] [v any/c]) boolean?]{
- Determines whether or not @racket[v] lies within @racket[rng] by comparing
+@defproc[(range-contains? [range range?] [v any/c]) boolean?]{
+ Determines whether or not @racket[v] lies within @racket[range] by comparing
  @racket[v] to its bounds, using the range's @tech{comparator}.
 
  @(examples
@@ -266,3 +266,16 @@ indication of whether the bound is inclusive or exclusive.
    (eval:error
     (range-encloses? (greater-than 2)
                      (greater-than "apple" #:comparator string<=>))))}
+
+@section{Operations on Ranges}
+
+@defproc[(range-span [range1 range?] [range2 range?]) range?]{
+ Returns the smallest range that @tech{encloses} both @racket[range1] and
+ @racket[range2]. The ranges need not be connected, but they must use the same
+ @tech{comparator}. This operation is commutative, associative, and idempotent.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (range-span (closed-range 2 5) (open-range 8 9))
+   (range-span (less-than 4) (singleton-range 6))
+   (range-span (open-range 2 8) (at-most 5)))}

--- a/private/range.scrbl
+++ b/private/range.scrbl
@@ -1,0 +1,238 @@
+#lang scribble/manual
+
+@(require (for-label racket/base
+                     racket/contract/base
+                     rebellion/base/comparator
+                     rebellion/base/range)
+          (submod rebellion/private/scribble-evaluator-factory doc)
+          scribble/example)
+
+@(define make-evaluator
+   (make-module-sharing-evaluator-factory
+    #:public (list 'rebellion/base/comparator
+                   'rebellion/base/range)
+    #:private (list 'racket/base)))
+
+@title{Ranges}
+@defmodule[rebellion/base/range]
+
+A @deftech{range}, also called an @deftech{interval}, is a contiguous set of
+ordered values. Ranges have at most two bounds: an upper bound and a lower
+bound. Either bound may be absent, in which case the range is @deftech{
+ unbounded}. If a bound is present, it contains an endpoint value and an
+indication of whether the bound is inclusive or exclusive.
+
+@section{Range Data Model}
+
+@defproc[(range? [v any/c]) boolean?]{
+ A predicate for @tech{ranges}.}
+
+@defproc[(range-lower-bound [rng range?]) (or/c range-bound? unbounded?)]{
+ Returns the lower bound of @racket[rng], or @racket[unbounded] if @racket[rng]
+ does not have a lower bound.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (range-lower-bound (closed-range 3 7))
+   (range-lower-bound (open-closed-range 3 7))
+   (range-lower-bound (at-least 5))
+   (range-lower-bound (less-than 14)))}
+
+@defproc[(range-upper-bound [rng range?]) (or/c range-bound? unbounded?)]{
+ Returns the upper bound of @racket[rng], or @racket[unbounded] if @racket[rng]
+ does not have an upper bound.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (range-upper-bound (closed-range 3 7))
+   (range-upper-bound (open-closed-range 3 7))
+   (range-upper-bound (at-least 5))
+   (range-upper-bound (less-than 14)))}
+
+@defproc[(range-comparator [rng range?]) comparator?]{
+ Returns the @tech{comparator} that @racket[rng] uses to compare values to its
+ bounds.}
+
+@defproc[(unbounded? [v any/c]) boolean?]{
+ A predicate for the @tech{unbounded} range endpoint constant.}
+
+@defthing[unbounded unbounded?]{
+ A constant used with the @racket[range] constructor to indicate that a @tech{
+  range} is @tech{unbounded} on one or both ends.}
+
+@defproc[(range-bound? [v any/c]) boolean?]{
+ A predicate for @tech{range} bounds, which contain an endpoint value and are
+ either inclusive or exclusive.}
+
+@defproc[(range-bound-endpoint [bound range-bound?]) any/c]{
+ Returns the endpoint value in @racket[bound].}
+
+@defproc[(range-bound-type [bound range-bound?]) range-bound-type?]{
+ Returns the type (inclusive or exclusive) of @racket[bound].}
+
+@defproc[(inclusive-bound [v any/c]) range-bound?]{
+ Constructs an @deftech{inclusive} @tech{range} bound, which includes values
+ equal to @racket[v]. An inclusive bound is also called a closed bound.}
+
+@defproc[(exclusive-bound [v any/c]) range-bound?]{
+ Constructs an @deftech{exclusive} @tech{range} bound, which does not include
+ values equal to @racket[v]. An exclusive bound is also called an open bound.}
+
+@defproc[(range-bound-type? [v any/c]) boolean?]{
+ A predicate for the two constants @racket[inclusive] and @racket[exclusive].}
+
+@deftogether[[
+ @defthing[inclusive range-bound-type?]
+ @defthing[exclusive range-bound-type?]]]{
+ Constants for the two types of @tech{range} bounds. An inclusive bound includes
+ the endpoint value, an exclusive bound does not include the endpoint value.}
+
+@section{Range Constructors}
+
+@defproc[(range [lower-bound (or/c range-bound? unbounded?)]
+                [upper-bound (or/c range-bound? unbounded?)]
+                [#:comparator comparator comparator? real<=>])
+         range?]{
+ Constructs a @tech{range} encompassing all values between @racket[lower-bound]
+ and @racket[upper-bound], when ordered according to @racket[comparator].
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (range (inclusive-bound 3) (exclusive-bound 7)))
+
+ Either @racket[lower-bound] or @racket[upper-bound] may be the special @racket[
+ unbounded] constant, indicating that the range is @tech{unbounded} on that end.
+ A range may be unbounded on both ends, in which case the range encompasses all
+ possible values (as long as they would be accepted by @racket[comparator]).
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (range (inclusive-bound 3) unbounded)
+   (range unbounded (exclusive-bound 7))
+   (range unbounded unbounded))
+
+ If the range is not unbounded, then @racket[lower-bound] must not be greater
+ than @racket[upper-bound] when compared with @racket[comparator].
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (eval:error (range (inclusive-bound 42) (exclusive-bound 17))))
+
+ However, @racket[lower-bound] @emph{may} be equal to @racket[upper-bound], as
+ long as at least one of the two bounds is inclusive. If both bounds are equal
+ and inclusive, this constructs a @deftech{singleton range} which contains only
+ one value. If one of the bounds is exclusive, the constructed range is an
+ @deftech{empty range} that contains no values. If both bounds are exclusive, a
+ contract violation is raised.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (range (inclusive-bound 5) (inclusive-bound 5))
+   (range (inclusive-bound 18) (exclusive-bound 18))
+   (eval:error (range (exclusive-bound 42) (exclusive-bound 42))))}
+
+@defproc[(closed-range [lower-endpoint any/c]
+                       [upper-endpoint any/c]
+                       [#:comparator comparator comparator? real<=>])
+         range?]{
+ Constructs a @tech{range} with inclusive lower and upper bounds of @racket[
+ lower-endpoint] and @racket[upper-endpoint]. The constructed range contains all
+ values between @racket[lower-endpoint] and @racket[upper-endpoint], including
+ both endpoints. Values are compared using @racket[comparator].}
+
+@defproc[(open-range [lower-endpoint any/c]
+                     [upper-endpoint any/c]
+                     [#:comparator comparator comparator? real<=>])
+         range?]{
+ Constructs a @tech{range} with exclusive lower and upper bounds of @racket[
+ lower-endpoint] and @racket[upper-endpoint]. The constructed range contains all
+ values between @racket[lower-endpoint] and @racket[upper-endpoint], but does
+ not include either endpoint. Values are compared using @racket[comparator].}
+
+@defproc[(closed-open-range [lower-endpoint any/c]
+                            [upper-endpoint any/c]
+                            [#:comparator comparator comparator? real<=>])
+         range?]{
+ Constructs a @tech{range} with an inclusive lower bound of @racket[
+ lower-endpoint] and an exclusive upper bound of @racket[upper-endpoint]. Values
+ are compared using @racket[comparator].}
+
+@defproc[(open-closed-range [lower-endpoint any/c]
+                            [upper-endpoint any/c]
+                            [#:comparator comparator comparator? real<=>])
+         range?]{
+ Constructs a @tech{range} with an exclusive lower bound of @racket[
+ lower-endpoint] and an inclusive upper bound of @racket[upper-endpoint]. Values
+ are compared using @racket[comparator].}
+
+@defproc[(at-least [lower-endpoint any/c]
+                   [#:comparator comparator comparator? real<=>])
+         range?]{
+ Constructs an unbounded-above @tech{range} with an inclusive lower bound of
+ @racket[lower-endpoint]. The constructed range includes every value that is
+ greater than or equal to @racket[lower-endpoint] according to @racket[
+ comparator].
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (at-least 14)
+   (range-contains? (at-least 14) 5)
+   (range-contains? (at-least 14) 14)
+   (range-contains? (at-least 14) 87))}
+
+@defproc[(at-most [upper-endpoint any/c]
+                  [#:comparator comparator comparator? real<=>])
+         range?]{
+ Constructs an unbounded-below @tech{range} with an inclusive upper bound of
+ @racket[upper-endpoint]. The constructed range includes every value that is
+ less than or equal to @racket[upper-endpoint] according to @racket[
+ comparator].
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (at-most 14)
+   (range-contains? (at-most 14) 5)
+   (range-contains? (at-most 14) 14)
+   (range-contains? (at-most 14) 87))}
+
+@defproc[(greater-than [lower-endpoint any/c]
+                       [#:comparator comparator comparator? real<=>])
+         range?]{
+ Constructs an unbounded-above @tech{range} with an exclusive lower bound of
+ @racket[lower-endpoint]. The constructed range includes every value that is
+ greater than @racket[lower-endpoint] according to @racket[comparator].
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (greater-than 14)
+   (range-contains? (greater-than 14) 5)
+   (range-contains? (greater-than 14) 14)
+   (range-contains? (greater-than 14) 87))}
+
+@defproc[(less-than [upper-endpoint any/c]
+                    [#:comparator comparator comparator? real<=>])
+         range?]{
+ Constructs an unbounded-below @tech{range} with an exclusive upper bound of
+ @racket[upper-endpoint]. The constructed range includes every value that is
+ less than @racket[upper-endpoint] according to @racket[comparator].
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (less-than 14)
+   (range-contains? (less-than 14) 5)
+   (range-contains? (less-than 14) 14)
+   (range-contains? (less-than 14) 87))}
+
+@section{Querying Ranges}
+
+@defproc[(range-contains? [rng range?] [v any/c]) boolean?]{
+ Determines whether or not @racket[v] lies within @racket[rng] by comparing
+ @racket[v] to its bounds, using the range's @tech{comparator}.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (range-contains? (closed-range 3 7) 5)
+   (range-contains? (closed-range 3 7) 7)
+   (range-contains? (closed-range 3 7) 10)
+   (range-contains? (greater-than "apple" #:comparator string<=>) "banana")
+   (range-contains? (greater-than "apple" #:comparator string<=>) "aardvark"))}

--- a/private/range.scrbl
+++ b/private/range.scrbl
@@ -223,6 +223,19 @@ indication of whether the bound is inclusive or exclusive.
    (range-contains? (less-than 14) 14)
    (range-contains? (less-than 14) 87))}
 
+@defproc[(singleton-range [endpoint any/c]
+                          [#:comparator comparator comparator? real<=>])
+         range?]{
+ Constructs a @tech{singleton range} that contains only values that are
+ equivalent to @racket[endpoint], according to @racket[comparator].
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (singleton-range 42)
+   (range-contains? (singleton-range 42) 42)
+   (range-contains? (singleton-range 42) 41)
+   (range-contains? (singleton-range 42) 43))}
+
 @section{Querying Ranges}
 
 @defproc[(range-contains? [rng range?] [v any/c]) boolean?]{

--- a/private/range.scrbl
+++ b/private/range.scrbl
@@ -267,6 +267,16 @@ indication of whether the bound is inclusive or exclusive.
     (range-encloses? (greater-than 2)
                      (greater-than "apple" #:comparator string<=>))))}
 
+@defproc[(range-connected? [range1 range?] [range2 range?]) boolean?]{
+ Determines whether or not there exists a (possibly empty) range that is @tech{
+  enclosed} by both @racket[range1] and @racket[range2].
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (range-connected? (closed-range 2 7) (open-range 3 8))
+   (range-connected? (closed-range 2 5) (open-range 5 8))
+   (range-connected? (open-range 2 5) (open-range 5 8)))}
+
 @section{Operations on Ranges}
 
 @defproc[(range-span [range1 range?] [range2 range?]) range?]{

--- a/private/range.scrbl
+++ b/private/range.scrbl
@@ -16,7 +16,7 @@
 @title{Ranges}
 @defmodule[rebellion/base/range]
 
-A @deftech{range}, also called an @deftech{interval}, is a contiguous set of
+A @deftech{range}, also called an @deftech{interval}, is a continuous set of
 ordered values. Ranges have at most two bounds: an upper bound and a lower
 bound. Either bound may be absent, in which case the range is @deftech{
  unbounded}. If a bound is present, it contains an endpoint value and an


### PR DESCRIPTION
This pull request is another stab at #315 and expands upon #333. Major differences from #333  include:

- The addition of 1) a _range bound_ data type which is either `(inclusive-bound x)` or `(exclusive-bound x)` and 2) an `unbounded` constant. With these, the `range` constructor encodes endpoint inclusivity and unbounded-ness in two arguments instead of four. Additionally, there is no need to use `rebellion/base/option` or to use `null` as a sentinel value.
- Several new constructors for making various kinds of ranges easier to construct. For example, the range `3 <= x <= 7` is written as `(closed-range 3 7)` and the range `x <= 42` is written as `(at-most 42)`.
- Allows empty ranges and singleton ranges. A singleton range has equal inclusive endpoints, while an empty range has equal inclusive-exclusive endpoints or exclusive-inclusive endpoints. Ranges with equal exclusive endpoints are invalid.
- Enforcement that the lower endpoint is less than or equal to the upper endpoint.
- Various naming differences.

The API is pretty lacking in useful features however. Besides the constructors, the only operation provided is `range-contains?` for testing if a range contains a certain value.