### PR TITLE
Add pattern matching support to rebellion/type

### DIFF
--- a/private/association-list.rkt
+++ b/private/association-list.rkt
@@ -76,7 +76,7 @@
         (cons prop:custom-write custom-write)))
 
 (define-record-type association-list (backing-hash size)
-  #:constructor-name constructor:association-list
+  #:omit-root-binding
   #:property-maker make-association-list-properties)
 
 (define (association-list . entries)

--- a/private/bitstring.rkt
+++ b/private/bitstring.rkt
@@ -64,7 +64,7 @@
         (cons prop:sequence sequence-impl)))
 
 (define-tuple-type bitstring (bytes padding)
-  #:constructor-name plain-bitstring
+  #:omit-root-binding
   #:property-maker make-bitstring-properties)
 
 (define (bitstring . bits)
@@ -99,7 +99,7 @@
   ;; merely contributes to memory pressure.
   (define padded-bytes (bytes->immutable-bytes mutable-padded-bytes))
 
-  (plain-bitstring padded-bytes padding-size))
+  (constructor:bitstring padded-bytes padding-size))
 
 (define (in-bitstring bits)
   (for/stream ([i (in-range (bitstring-size bits))])
@@ -110,7 +110,7 @@
 (define (bitstring->padded-bytes bits) (bitstring-bytes bits))
 
 (define (bytes->bitstring bytes #:padding [padding 0])
-  (cond [(zero? padding) (plain-bitstring bytes 0)]
+  (cond [(zero? padding) (constructor:bitstring bytes 0)]
         [else
          (define size (bytes-length bytes))
          (define last-pos (sub1 size))
@@ -121,7 +121,7 @@
          (define padded-last-byte (byte-clear-rightmost-bits last-byte padding))
          (bytes-set! mutable-padded-bytes last-pos padded-last-byte)
          (define padded-bytes (bytes->immutable-bytes mutable-padded-bytes))
-         (plain-bitstring padded-bytes padding)]))
+         (constructor:bitstring padded-bytes padding)]))
 
 (module+ test
   (test-case (name-string bitstring)

--- a/private/enum-type-base.rkt
+++ b/private/enum-type-base.rkt
@@ -28,7 +28,7 @@
 
 (define-tuple-type enum-type
   (name cases predicate-name discriminator-name selector-name)
-  #:constructor-name constructor:enum-type)
+  #:omit-root-binding)
 
 (define (enum-type name fields
                    #:predicate-name [predicate-name* #f]

--- a/private/enum-type.rkt
+++ b/private/enum-type.rkt
@@ -5,7 +5,6 @@
 (require (for-syntax racket/base
                      racket/sequence
                      racket/syntax)
-         racket/match
          rebellion/collection/keyset/low-dependency
          rebellion/type/enum/base
          rebellion/type/enum/descriptor
@@ -52,17 +51,13 @@
                 #:defaults ([prop-maker #'default-enum-properties])
                 #:name "#:property-maker option"))
     ...)
-  #:with (local-case-id ...) (generate-temporaries #'(cases.id ...))
   (begin
     (define type (enum-type 'id cases.names #:predicate-name 'predicate-name))
     (define descriptor
       (make-enum-implementation type #:property-maker prop-maker))
     (define predicate-name (enum-descriptor-predicate descriptor))
     (define selector (enum-descriptor-selector descriptor))
-    (define local-case-id (selector cases.index)) ...
-    (define-match-expander cases.id
-      (syntax-parser [_:id #'(== cases.id)])
-      (make-rename-transformer #'local-case-id))
+    (define cases.id (selector cases.index))
     ...))
 
 (module+ test
@@ -76,7 +71,6 @@
     (check-false (compass-direction? 42))
     (check-equal? (object-name compass-direction?) (name compass-direction?))
     (check-equal? (object-name north) (name north))
-    (check-match north north)
     (check-equal? (~a south) "#<compass-direction:south>")
     (check-equal? (~v east) "#<compass-direction:east>")
     (check-equal? (~s west) "#<compass-direction:west>")))

--- a/private/enum-type.rkt
+++ b/private/enum-type.rkt
@@ -5,6 +5,7 @@
 (require (for-syntax racket/base
                      racket/sequence
                      racket/syntax)
+         racket/match
          rebellion/collection/keyset/low-dependency
          rebellion/type/enum/base
          rebellion/type/enum/descriptor
@@ -51,13 +52,17 @@
                 #:defaults ([prop-maker #'default-enum-properties])
                 #:name "#:property-maker option"))
     ...)
+  #:with (local-case-id ...) (generate-temporaries #'(cases.id ...))
   (begin
     (define type (enum-type 'id cases.names #:predicate-name 'predicate-name))
     (define descriptor
       (make-enum-implementation type #:property-maker prop-maker))
     (define predicate-name (enum-descriptor-predicate descriptor))
     (define selector (enum-descriptor-selector descriptor))
-    (define cases.id (selector cases.index))
+    (define local-case-id (selector cases.index)) ...
+    (define-match-expander cases.id
+      (syntax-parser [_:id #'(== cases.id)])
+      (make-rename-transformer #'local-case-id))
     ...))
 
 (module+ test
@@ -71,6 +76,7 @@
     (check-false (compass-direction? 42))
     (check-equal? (object-name compass-direction?) (name compass-direction?))
     (check-equal? (object-name north) (name north))
+    (check-match north north)
     (check-equal? (~a south) "#<compass-direction:south>")
     (check-equal? (~v east) "#<compass-direction:east>")
     (check-equal? (~s west) "#<compass-direction:west>")))

--- a/private/media.rkt
+++ b/private/media.rkt
@@ -57,7 +57,7 @@
         (cons prop:custom-write custom-write)))
 
 (define-tuple-type media-type (top-level tree subtype suffix parameters)
-  #:constructor-name constructor:media-type
+  #:omit-root-binding
   #:property-maker make-media-type-properties)
 
 (define (media-type top-level subtype

--- a/private/multidict.rkt
+++ b/private/multidict.rkt
@@ -106,7 +106,7 @@
 
 ;@------------------------------------------------------------------------------
 (define-record-type multidict (size backing-hash inverted-hash keys values)
-  #:constructor-name constructor:multidict
+  #:omit-root-binding
   #:property-maker make-multidict-properties)
 
 (define (in-multidict-entries dict) dict)

--- a/private/multiset.rkt
+++ b/private/multiset.rkt
@@ -66,7 +66,7 @@
 
 (define-record-type multiset (size frequencies unique-elements)
   #:property-maker make-multiset-props
-  #:constructor-name constructor:multiset)
+  #:omit-root-binding)
 
 (define empty-hash (hash))
 (define empty-set (set))

--- a/private/octet-stream.rkt
+++ b/private/octet-stream.rkt
@@ -29,11 +29,10 @@
 ;@------------------------------------------------------------------------------
 
 ;; TODO: handle the "type" parameter
-(define-tuple-type octet-stream (bytes padding)
-  #:constructor-name plain-octet-stream)
+(define-tuple-type octet-stream (bytes padding) #:omit-root-binding)
 
 (define (octet-stream bytes #:padding [padding 0])
-  (plain-octet-stream bytes padding))
+  (constructor:octet-stream bytes padding))
 
 (define (octet-stream->bitstring octets)
   (bytes->bitstring (octet-stream-bytes octets)

--- a/private/permutation.rkt
+++ b/private/permutation.rkt
@@ -46,7 +46,7 @@
         (cons prop:custom-write custom-write)))
 
 (define-tuple-type permutation (vector)
-  #:constructor-name permutation-constructor
+  #:omit-root-binding
   #:property-maker make-permutation-properties)
 
 (define (permutation-size/c expected-size)
@@ -70,7 +70,7 @@
   #:fail-when (check-position-bounds #'(position ...) size)
   (format "position out of bounds for permutation of size ~a" size)
   #:fail-when (check-duplicate-position #'(position ...)) "duplicate position"
-  (permutation-constructor (vector-immutable position ...)))
+  (constructor:permutation (vector-immutable position ...)))
 
 (define-simple-macro (cyclic-permutation position:nat ...+)
   #:do [(define positions
@@ -87,7 +87,7 @@
           (define next-pos (vector-ref positions-vec j))
           (vector-set! vec next-pos pos))]
   #:with vec #`(quote #,(vector->immutable-vector vec))
-  (permutation-constructor vec))
+  (constructor:permutation vec))
 
 (define empty-permutation (permutation))
 

--- a/private/range.rkt
+++ b/private/range.rkt
@@ -172,7 +172,7 @@
 ;; Data model
 
 (define-tuple-type range (lower-bound upper-bound comparator)
-  #:constructor-name constructor:range)
+  #:omit-root-binding)
 
 (define-singleton-type unbounded)
 

--- a/private/record-type-base.rkt
+++ b/private/record-type-base.rkt
@@ -25,7 +25,7 @@
 
 (define-tuple-type record-type
   (name fields predicate-name constructor-name accessor-name)
-  #:constructor-name constructor:record-type)
+  #:omit-root-binding)
 
 (define (record-type name fields
                      #:predicate-name [predicate-name* #f]

--- a/private/record-type.rkt
+++ b/private/record-type.rkt
@@ -5,6 +5,7 @@
 (require (for-syntax racket/base
                      racket/sequence
                      racket/syntax)
+         racket/match
          rebellion/collection/keyset/low-dependency
          rebellion/type/record/base
          rebellion/type/record/descriptor
@@ -17,43 +18,68 @@
 
 ;@------------------------------------------------------------------------------
 
+(begin-for-syntax
+  (define-syntax-class record-fields
+    #:attributes ([id 1] [keyword 1] keys [position 1])
+    (pattern (unsorted-id:id ...)
+      #:with (id ...)
+      (sort (syntax->list #'(unsorted-id ...)) symbol<? #:key syntax-e)
+      #:with (keyword ...)
+      (for/list ([id-stx (in-syntax #'(id ...))])
+        (string->keyword (symbol->string (syntax-e id-stx))))
+      #:with keys #'(keyset keyword ...)
+      #:with (position ...)
+      (for/list ([_ (in-syntax #'(id ...))] [n (in-naturals)]) #`'#,n))))
+
 (define-simple-macro
-  (define-record-type id:id (field-id:id ...)
+  (define-record-type id:id fields:record-fields
     (~alt
-     (~optional (~seq #:predicate-name predicate-name:id)
-                #:defaults
-                ([predicate-name (format-id #'id "~a?" #'id #:subs? #t)])
+     (~optional (~and #:omit-root-binding omit-root-binding-kw))
+     (~optional (~seq #:predicate-name predicate:id)
+                #:defaults ([predicate (format-id #'id "~a?" #'id #:subs? #t)])
                 #:name "#:predicate-name option")
-     (~optional (~seq #:constructor-name constructor-name:id)
-                #:defaults ([constructor-name #'id])
-                #:name "#:constructor-name option")
+     (~optional
+      (~seq #:constructor-name constructor:id)
+      #:defaults
+      ([constructor (format-id #'id "constructor:~a" #'id #:subs? #t)])
+      #:name "#:constructor-name option")
+     (~optional
+      (~seq #:pattern-name pattern:id)
+      #:defaults ([pattern (format-id #'id "pattern:~a" #'id #:subs? #t)])
+      #:name "#:constructor-name option")
      (~optional (~seq #:property-maker prop-maker:expr)
                 #:defaults ([prop-maker #'default-record-properties])
                 #:name "#:property-maker option"))
     ...)
-  #:with fields
-  #`(keyset
-     #,@(for/list ([field-id-stx (in-syntax #'(field-id ...))])
-          (string->keyword (symbol->string (syntax-e field-id-stx)))))
-  #:with (sorted-field-id ...)
-  (sort (syntax->list #'(field-id ...)) symbol<? #:key syntax-e)
-  #:with (field-accessor-id ...)
-  (for/list ([field-id-stx (in-syntax #'(sorted-field-id ...))])
-    (format-id field-id-stx "~a-~a" #'id field-id-stx #:subs? #t))
-  #:with (position ...)
-  (for/list ([n (in-range (length (syntax->list #'(field-id ...))))])
-    #`(quote #,n))
+  #:with (field-accessor ...)
+  (for/list ([field-id-stx (in-syntax #'(fields.id ...))])
+    (format-id #'id "~a-~a" #'id field-id-stx #:subs? #t))
+  #:with root-binding
+  (if (attribute omit-root-binding-kw)
+      #'(begin)
+      #'(define-match-expander id
+          (syntax-parser
+            [(_ (~alt (~optional (~seq fields.keyword fields.id)) ...)
+                (... ...))
+             #'(pattern (... (~? (~@ fields.keyword fields.id))) ...)])
+          (make-rename-transformer #'constructor)))
   (begin
     (define type
-      (record-type 'id fields
-                   #:predicate-name 'predicate-name
-                   #:constructor-name 'constructor-name))
+      (record-type 'id fields.keys
+                   #:predicate-name 'predicate
+                   #:constructor-name 'constructor))
     (define descriptor
       (make-record-implementation type #:property-maker prop-maker))
-    (define predicate-name (record-descriptor-predicate descriptor))
-    (define constructor-name (record-descriptor-constructor descriptor))
-    (define field-accessor-id (make-record-field-accessor descriptor position))
-    ...))
+    (define predicate (record-descriptor-predicate descriptor))
+    (define constructor (record-descriptor-constructor descriptor))
+    (define field-accessor
+      (make-record-field-accessor descriptor fields.position))
+    ...
+    (define-match-expander pattern
+      (syntax-parser
+        [(_ (~alt (~optional (~seq fields.keyword fields.id)) ...) (... ...))
+         #'(? predicate ((... ~?) (app field-accessor fields.id)) ...)]))
+    root-binding))
 
 (module+ test
   (define-record-type person (name age favorite-color))
@@ -63,6 +89,8 @@
   (check-equal? (person-age ted) 42)
   (check-equal? (person-favorite-color ted) 'grey)
   (check-true (person? ted))
+  (check-match ted (person #:age 42))
+  (check-match ted (person #:name (? string?) #:favorite-color 'grey))
   (define-record-type plant (name))
   (check-false (person? (plant #:name "Cactus")))
   (check-equal? (~a ted)

--- a/private/record.rkt
+++ b/private/record.rkt
@@ -56,11 +56,11 @@
         (cons prop:custom-write custom-write)))
 
 (define-tuple-type record (keywords values)
-  #:constructor-name internal-record-constructor
+  #:omit-root-binding
   #:property-maker make-record-properties)
 
 (define (record-keyword-procedure kws vs)
-  (internal-record-constructor (list->keyset kws) (list->immutable-vector vs)))
+  (constructor:record (list->keyset kws) (list->immutable-vector vs)))
 
 (define record
   (procedure-reduce-keyword-arity
@@ -129,7 +129,7 @@
   (define kws (record-keywords rec))
   (define vs (record-values rec))
   (define mapped-vs (immutable-vector-map f vs))
-  (internal-record-constructor kws mapped-vs))
+  (constructor:record kws mapped-vs))
 
 (define (build-record builder keys)
   (define vs
@@ -137,7 +137,7 @@
      (for/vector #:length (keyset-size keys)
        ([kw (in-keyset keys)])
        (builder kw))))
-  (internal-record-constructor keys vs))
+  (constructor:record keys vs))
 
 (define (record-contains-key? rec kw)
   (keyset-contains? (record-keywords rec) kw))
@@ -186,7 +186,7 @@
         (cons prop:custom-write custom-write)))
 
 (define-tuple-type record-field (name value)
-  #:constructor-name constructor:record-field
+  #:omit-root-binding
   #:property-maker make-record-field-properties)
 
 (define (record-field-keyword-function kws kw-args)

--- a/private/reference-type-base.rkt
+++ b/private/reference-type-base.rkt
@@ -30,7 +30,7 @@
 
 (define-record-type reference-type
   (name fields object-name-field constructor-name predicate-name accessor-name)
-  #:constructor-name constructor:reference-type)
+  #:omit-root-binding)
 
 (define (reference-type name fields
                         #:object-name-field [name-field

--- a/private/singleton-type-base.rkt
+++ b/private/singleton-type-base.rkt
@@ -16,8 +16,7 @@
 
 ;@------------------------------------------------------------------------------
 
-(define-tuple-type singleton-type (name predicate-name)
-  #:constructor-name constructor:singleton-type)
+(define-tuple-type singleton-type (name predicate-name) #:omit-root-binding)
 
 (define (singleton-type name #:predicate-name [pred-name #f])
   (constructor:singleton-type name pred-name))

--- a/private/singleton-type-descriptor.rkt
+++ b/private/singleton-type-descriptor.rkt
@@ -35,7 +35,7 @@
 
 (define-tuple-type initialized-singleton-descriptor
   (type instance predicate)
-  #:constructor-name constructor:initialized-singleton-descriptor
+  #:omit-root-binding
   #:property-maker make-singleton-properties)
 
 (define (initialized-singleton-descriptor #:type type
@@ -45,7 +45,7 @@
 
 (define-tuple-type uninitialized-singleton-descriptor
   (type predicate)
-  #:constructor-name constructor:uninitialized-singleton-descriptor
+  #:omit-root-binding
   #:property-maker make-singleton-properties)
 
 (define (uninitialized-singleton-descriptor #:type type #:predicate predicate)

--- a/private/table.rkt
+++ b/private/table.rkt
@@ -75,7 +75,7 @@
         (cons prop:equal+hash (default-record-equal+hash descriptor))))
 
 (define-record-type table (backing-column-vectors size)
-  #:constructor-name constructor:table
+  #:omit-root-binding
   #:property-maker make-table-properties)
 
 (define-syntax (columns stx)

--- a/private/tuple-type.rkt
+++ b/private/tuple-type.rkt
@@ -5,21 +5,33 @@
 (require (for-syntax racket/base
                      racket/sequence
                      racket/syntax)
+         racket/match
          rebellion/type/tuple/base
          rebellion/type/tuple/descriptor
          syntax/parse/define)
+
+(module+ test
+  (require (submod "..")
+           rackunit
+           rebellion/private/static-name))
 
 ;@------------------------------------------------------------------------------
 
 (define-simple-macro
   (define-tuple-type id:id (field:id ...)
     (~alt
-     (~optional (~seq #:constructor-name constructor:id)
-                #:defaults ([constructor #'id]))
+     (~optional (~and #:omit-root-binding omit-root-binding-kw))
+     (~optional
+      (~seq #:constructor-name constructor:id)
+      #:defaults
+      ([constructor (format-id #'id "constructor:~a" #'id #:subs? #t)]))
      (~optional (~seq #:predicate-name predicate:id)
                 #:defaults ([predicate (format-id #'id "~a?" #'id #:subs? #t)]))
      (~optional (~seq #:property-maker property-maker:expr)
-                #:defaults ([property-maker #'default-tuple-properties])))
+                #:defaults ([property-maker #'default-tuple-properties]))
+     (~optional
+      (~seq #:pattern-name pattern:id)
+      #:defaults ([pattern (format-id #'id "pattern:~a" #'id #:subs? #t)])))
     ...)
   #:do [(define size (length (syntax->list #'(field ...))))]
   #:with quoted-size #`(quote #,size)
@@ -27,6 +39,13 @@
   (for/list ([field-id (in-syntax #'(field ...))])
     (format-id field-id "~a-~a" #'id field-id #:subs? #t))
   #:with (field-position ...) (build-list size (λ (n) #`(quote #,n)))
+  #:with root-binding
+  (if (attribute omit-root-binding-kw)
+      #'(begin)
+      #'(...
+         (define-match-expander id
+           (syntax-parser [(_ rest ...) #'(pattern rest ...)])
+           (make-rename-transformer #'constructor))))
   (begin
     (define descriptor
       (make-tuple-implementation
@@ -38,4 +57,25 @@
     (define predicate (tuple-descriptor-predicate descriptor))
     (define field-accessor
       (make-tuple-field-accessor descriptor field-position 'field))
-    ...))
+    ...
+    (define-match-expander pattern
+      (syntax-parser
+        [(_ field ...) #'(? predicate (app field-accessor field) ...)]))
+    root-binding))
+
+(module+ test
+  (test-case (name-string define-tuple-type)
+    (define-tuple-type point (x y))
+    (check-pred point? (point 1 2))
+    (check-equal? (point-x (point 1 2)) 1)
+    (check-equal? (point-y (point 1 2)) 2)
+    (check-equal? (point 1 2) (point 1 2))
+    (check-pred point? (apply point (list 1 2)))
+    (check-match (point 1 2) (point x _) (equal? x 1))
+    (check-match (point 1 2) (point _ y) (equal? y 2))
+
+    (test-case "should allow omitting the root binding"
+      (define-tuple-type point (x y) #:omit-root-binding)
+      (check-match (constructor:point 1 2) (pattern:point x y)
+                   (and (equal? x 1) (equal? y 2)))
+      (check-pred point? (apply constructor:point (list 1 2))))))

--- a/private/tuple-type.scrbl
+++ b/private/tuple-type.scrbl
@@ -164,9 +164,9 @@ represent a single logical thing, and there is an obvious order to those pieces.
        (listof (cons/c struct-type-property? any/c)))
    default-tuple-properties])
  initialized-tuple-descriptor?]{
- Implements @racket[type] and returns a @tech{tuple type descriptor} for the
- new implementation. The @racket[guard] and @racket[inspector] arguments behave
- the same as the corresponding arguments of @racket[make-struct-type], although
+ Implements @racket[type] and returns a @tech{type descriptor} for the new
+ implementation. The @racket[guard] and @racket[inspector] arguments behave the
+ same as the corresponding arguments of @racket[make-struct-type], although
  there are no transparent or prefab tuple types. The @racket[prop-maker]
  argument is similar to the corresponding argument of @racket[
  make-struct-implementation]. By default, tuple types are created with

--- a/private/tuple-type.scrbl
+++ b/private/tuple-type.scrbl
@@ -2,6 +2,8 @@
 
 @(require (for-label racket/base
                      racket/contract/base
+                     racket/contract/region
+                     racket/match
                      racket/math
                      racket/pretty
                      racket/struct
@@ -9,33 +11,97 @@
                      rebellion/equal+hash
                      rebellion/type/tuple
                      rebellion/type/struct)
+          (submod rebellion/private/scribble-cross-document-tech doc)
           (submod rebellion/private/scribble-evaluator-factory doc)
           scribble/examples)
 
 @(define make-evaluator
    (make-module-sharing-evaluator-factory
-    #:public (list 'racket/pretty
+    #:public (list 'racket/contract/base
+                   'racket/contract/region
+                   'racket/match
+                   'racket/math
+                   'racket/pretty
                    'rebellion/type/tuple)
     #:private (list 'racket/base)))
 
 @title{Tuple Types}
 @defmodule[rebellion/type/tuple]
 
-A @deftech{tuple type} is a data type representing immutable fixed-size
-sequences of unnamed values, each of which is a @deftech{tuple instance} of the
-tuple type. All instances of a tuple type are the same size, and that size is
-accessible from the type using @racket[tuple-type-size].
+A @deftech{tuple type} is a kind of @tech{data type} for composite values that
+contain an ordered list of fields. The definition of each tuple type declares
+how many fields it has and what their names are, although those names are only
+observable at compile time. Constructing an instance of a tuple type requires
+passing a positional argument for each field to the type's constructor. Tuple
+types are useful when a fixed number of different pieces of data together
+represent a single logical thing, and there is an obvious order to those pieces.
 
-Tuple types are specifications, not implementations. A tuple type does not
-directly provide a constructor or accessor; it only provides information about
-the type such as its symbolic name, the number of fields, etc. An actual
-implementation of a tuple type is obtained via @racket[
- make-tuple-implementation], which generates a new implementation of a
-tuple type and returns a @deftech{tuple type descriptor} object. Descriptors
-provide functions that implement the type and a predicate that identifies the
-implementation's values. Descriptors are generative; calling @racket[
- make-tuple-implementation] with the same tuple type will make multiple
-distinct implementations of that type.
+@(examples
+  #:eval (make-evaluator) #:once
+  (eval:no-prompt
+   (define-tuple-type point (x y))
+
+   (define/contract (point-distance start end)
+     (-> point? point? real?)
+     (match-define (point x1 y1) start)
+     (match-define (point x2 y2) end)
+     (define dx (- x2 x1))
+     (define dy (- y2 y1))
+     (sqrt (+ (sqr dx) (sqr dy)))))
+
+  (point-distance (point 0 0) (point 3 4))
+  (eval:error (point-distance (point 0 0) (list 3 4))))
+
+@defform[
+ (define-tuple-type id (field-id ...) option ...)
+
+ #:grammar
+ ([option
+   #:omit-root-binding
+   (code:line #:constructor-name constructor-id)
+   (code:line #:predicate-name predicate-id)
+   (code:line #:pattern-name pattern-id)
+   (code:line #:property-maker prop-maker-expr)])
+
+ #:contracts
+ ([prop-maker-expr
+   (-> uninitialized-tuple-descriptor?
+       (listof (cons/c struct-type-property? any/c)))])]{
+ Creates a new @tech{tuple type} named @racket[id] and binds the following
+ identifiers:
+
+ @itemlist[
+ @item{@racket[constructor-id], which defaults to @racketidfont{
+    constructor:}@racket[id] --- a constructor function that accepts one
+   positional argument for each @racket[field-id] and returns an instance of the
+   created type.}
+
+ @item{@racket[predicate-id], which defaults to @racket[id]@racketidfont{?} ---
+   a predicate function that returns @racket[#t] when given instances of the
+   created type and returns @racket[#f] otherwise.}
+
+ @item{@racket[id]@racketidfont{-}@racket[field-id] for each @racket[field-id]
+   --- an accessor function that returns the value for @racket[field-id] when
+   given an instance of the created type.}
+
+ @item{@racket[pattern-id], which defaults to @racketidfont{pattern:}@racket[id]
+   --- a @tech/reference{match expander} that deconstructs instances of the
+   created type and matches each field against a subpattern}]
+
+ Additionally, unless @racket[#:omit-root-binding] is specified, the original
+ @racket[id] is bound to @racket[pattern-id] when used in match patterns and to
+ @racket[constructor-id] when used as an expression. Use @racket[
+ #:omit-root-binding] when you want control over what @racket[id] is bound to,
+ such as when creating a smart constructor.
+ 
+ @(examples
+   #:eval (make-evaluator) #:once
+   (define-tuple-type point (x y))
+   (point 1 2)
+   (point? (point 1 2))
+   (point-x (point 42 0))
+   (point-y (point 42 0))
+   (match-define (point (? positive? x) (? negative? y)) (point 3 -3)))}
 
 @defproc[(tuple-type? [v any/c]) boolean?]{
  A predicate for @tech{tuple types}.}
@@ -66,12 +132,12 @@ distinct implementations of that type.
  Accessors for the various fields of a @tech{tuple type}.}
 
 @defproc[(tuple-descriptor? [v any/c]) boolean?]{
- A predicate for @tech{tuple type descriptors}.}
+ A predicate for @tech{type descriptors} of @tech{tuple types}.}
 
 @deftogether[[
  @defproc[(initialized-tuple-descriptor? [v any/c]) boolean?]
  @defproc[(uninitialized-tuple-descriptor? [v any/c]) boolean?]]]{
- Predicates for @tech{tuple type descriptors} that either have or haven't been
+ Predicates for tuple @tech{type descriptors} that either have or haven't been
  initialized yet. The predicate, constructor, and accessor of an uninitialized
  tuple descriptor @bold{must not be called until initialization is complete}, as
  the implementations of those functions won't exist until then. Initialization
@@ -86,7 +152,7 @@ distinct implementations of that type.
           procedure?]
  @defproc[(tuple-descriptor-accessor [descriptor tuple-descriptor?])
           (-> (tuple-descriptor-predicate descriptor) natural? any/c)]]]{
- Accessors for the various fields of a @tech{tuple type descriptor}.}
+ Accessors for the various fields of a tuple @tech{type descriptor}.}
 
 @defproc[
  (make-tuple-implementation
@@ -172,21 +238,3 @@ distinct implementations of that type.
    (point 1 2)
    (parameterize ([pretty-print-columns 10])
      (pretty-print (point 100000000000000 200000000000000))))}
-
-@defform[
- (define-tuple-type id (field-id ...) option ...)
- #:grammar
- ([option (code:line #:constructor-name constructor-id)
-   (code:line #:predicate-name predicate-id)
-   (code:line #:property-maker prop-maker-expr)])
- #:contracts
- ([prop-maker-expr (-> uninitialized-tuple-descriptor?
-                       (listof (cons/c struct-type-property? any/c)))])]{
- Defines a new @tech{tuple type}.
-
- @(examples
-   #:eval (make-evaluator) #:once
-   (define-tuple-type point (x y))
-   (point 1 2)
-   (point-x (point 42 0))
-   (point-y (point 42 0)))}

--- a/private/variant.rkt
+++ b/private/variant.rkt
@@ -36,7 +36,7 @@
         (cons prop:equal+hash (default-tuple-equal+hash descriptor))))
 
 (define-tuple-type variant (tag value)
-  #:constructor-name constructor:variant
+  #:omit-root-binding
   #:property-maker make-variant-properties)
 
 (define (variant-keyword-function kws kw-args)

--- a/private/web-graph.rkt
+++ b/private/web-graph.rkt
@@ -34,7 +34,7 @@
 
 (define-tuple-type web-graph (links)
   #:property-maker property-maker
-  #:constructor-name constructor:web-graph)
+  #:omit-root-binding)
 
 (define (web-graph . links)
   (constructor:web-graph links))

--- a/private/web-link.rkt
+++ b/private/web-link.rkt
@@ -50,7 +50,7 @@
 
 (define-tuple-type web-link (source relation target)
   #:property-maker property-maker
-  #:constructor-name constructor:web-link)
+  #:omit-root-binding)
 
 (define (web-link source relation target)
   (constructor:web-link (url-coerce source)

--- a/private/wrapper-type-base.rkt
+++ b/private/wrapper-type-base.rkt
@@ -24,7 +24,7 @@
 
 (define-record-type wrapper-type
   (name predicate-name constructor-name accessor-name)
-  #:constructor-name constructor:wrapper-type)
+  #:omit-root-binding)
 
 (define (wrapper-type
          name

--- a/private/wrapper-type.rkt
+++ b/private/wrapper-type.rkt
@@ -4,6 +4,7 @@
 
 (require (for-syntax racket/base
                      racket/syntax)
+         racket/match
          rebellion/type/wrapper/base
          rebellion/type/wrapper/descriptor
          syntax/parse/define)
@@ -17,20 +18,34 @@
 
 (define-simple-macro
   (define-wrapper-type id:id
-    (~alt (~optional (~seq #:predicate-name predicate-name:id)
-                     #:defaults ([predicate-name (format-id #'id "~a?" #'id)])
-                     #:name "#:predicate-name option")
-          (~optional (~seq #:constructor-name constructor-name:id)
-                     #:defaults ([constructor-name #'id])
-                     #:name "#:constructor-name option")
-          (~optional (~seq #:accessor-name accessor-name:id)
-                     #:defaults ([accessor-name
-                                  (format-id #'id "~a-value" #'id)])
-                     #:name "#:accessor-name option")
-          (~optional (~seq #:property-maker prop-maker:expr)
-                     #:defaults ([prop-maker #'default-wrapper-properties])
-                     #:name "#:property-maker option"))
+    (~alt
+     (~optional (~and #:omit-root-binding omit-root-binding-kw))
+     (~optional (~seq #:predicate-name predicate-name:id)
+                #:defaults ([predicate-name (format-id #'id "~a?" #'id)])
+                #:name "#:predicate-name option")
+     (~optional
+      (~seq #:constructor-name constructor-name:id)
+      #:defaults ([constructor-name (format-id #'id "constructor:~a" #'id)])
+      #:name "#:constructor-name option")
+     (~optional (~seq #:accessor-name accessor-name:id)
+                #:defaults ([accessor-name
+                             (format-id #'id "~a-value" #'id)])
+                #:name "#:accessor-name option")
+     (~optional
+      (~seq #:pattern-name pattern-name:id)
+      #:defaults ([pattern-name (format-id #'id "pattern:~a" #'id)])
+      #:name "#:pattern-name option")
+     (~optional (~seq #:property-maker prop-maker:expr)
+                #:defaults ([prop-maker #'default-wrapper-properties])
+                #:name "#:property-maker option"))
     ...)
+  #:with root-binding
+  (if (attribute omit-root-binding-kw)
+      #'(begin)
+      #'(...
+         (define-match-expander id
+           (syntax-parser [(_ value-pattern) #'(pattern-name value-pattern)])
+           (make-rename-transformer #'constructor-name))))
   (begin
     (define type
       (wrapper-type 'id
@@ -41,13 +56,26 @@
       (make-wrapper-implementation type #:property-maker prop-maker))
     (define predicate-name (wrapper-descriptor-predicate descriptor))
     (define constructor-name (wrapper-descriptor-constructor descriptor))
-    (define accessor-name (wrapper-descriptor-accessor descriptor))))
+    (define accessor-name (wrapper-descriptor-accessor descriptor))
+    (define-match-expander pattern-name
+      (syntax-parser
+        [(_ value-pattern)
+         #'(? predicate-name (app accessor-name value-pattern))]))
+    root-binding))
 
 (module+ test
   (test-case "integration-test"
     (define-wrapper-type seconds)
     (check-equal? (seconds 10) (seconds 10))
     (check-not-equal? (seconds 10) (seconds 25))
+    (check-equal? (constructor:seconds 10) (seconds 10))
     (check-equal? (seconds-value (seconds 10)) 10)
     (check-pred seconds? (seconds 10))
-    (check-equal? (~v (seconds 10)) "(seconds 10)")))
+    (check-equal? (~v (seconds 10)) "(seconds 10)")
+    (check-match (seconds 10) (seconds (? number?)))
+    (check-match (seconds 10) (pattern:seconds (? number?)))
+
+    (test-case "omit-root-binding option"
+      (define-wrapper-type minutes #:omit-root-binding)
+      (define (minutes x) (constructor:minutes x))
+      (check-match (minutes 30) (pattern:minutes (? number?))))))


### PR DESCRIPTION
This PR implements pattern matching support for record, tuple, and wrapper types. This *does not* implement any sort of generic match expander for each kind of type, nor does it add any static type information. Instead, the type definition macros like `define-tuple-type` simply bind one-off patterns implemented directly using `app` and the type's field accessors. This avoids the need to finish implementing #197.

**This change is backwards incompatible.** (cc @samdphillips) Before this change, many type definitions used `#:constructor-name` to omit binding the type name to a constructor in order to allow defining a smart constructor with that name. After this change, that code won't compile because using `#:constructor-name` is not enough to omit binding the type name - it will still be bound to a match expander. The fix is for the type definition to use `#:omit-root-binding`, a new keyword option which all of the type definition macros that bind match expanders now support.

Match expanders are not defined for enum, singleton, or reference types. Enum and singleton types cannot currently include match expanders, because there's no way to define a match expander that can be used like a variable (e.g. `(match foo [variable-like-expander 42])`). Instead, enums and singletons should be matched using `==`. Reference types are not included because they're more like "objects" than "data", and exposing a match expander would give clients of a reference type the ability to tell the difference between a reference type field and a function operating on the reference type. Reference types usually care a lot about that sort of encapsulation.

Closes #180.