### PR TITLE
Add reducer contracts

### DIFF
--- a/private/association-list.scrbl
+++ b/private/association-list.scrbl
@@ -3,6 +3,7 @@
 @(require (for-label racket/base
                      racket/contract/base
                      racket/math
+                     racket/set
                      rebellion/collection/association-list
                      rebellion/collection/entry
                      rebellion/collection/immutable-vector
@@ -89,7 +90,8 @@ key-value pairs.
    (association-list-keys (association-list 'a 1 'a 1 'b 2 'b 2 'c 3)))}
 
 @defproc[(association-list-unique-keys [assoc association-list?]) set?]{
- Returns a @tech/reference{set} containing the keys in @racket[assoc], without duplicates.
+ Returns a @tech/reference{set} containing the keys in @racket[assoc], without
+ duplicates.
 
  @(examples
    #:eval (make-evaluator) #:once

--- a/private/comparator.rkt
+++ b/private/comparator.rkt
@@ -155,10 +155,11 @@
                                 #:chaperone? [chaperone? (not guard)])
   (define function (comparator-function comparator))
   (define impersonated-function
-    (function-impersonate function
-                          #:guard (and guard (comparator-function-guard guard))
-                          #:application-marks marks
-                          #:chaperone? chaperone?))
+    (function-impersonate
+     function
+     #:arguments-guard (and guard (comparator-function-guard guard))
+     #:application-marks marks
+     #:chaperone? chaperone?))
   (define impersonated-without-props
     (make-comparator impersonated-function #:name (object-name comparator)))
   (reference-impersonate impersonated-without-props descriptor:comparator

--- a/private/hash.rkt
+++ b/private/hash.rkt
@@ -11,10 +11,12 @@
   [nonempty-immutable-hash? predicate/c]
   [in-hash-entries (-> immutable-hash? (sequence/c entry?))]
   [in-mutable-hash-entries (-> mutable-hash? (sequence/c entry?))]
-  [into-hash reducer?]
-  [into-mutable-hash reducer?]
-  [combine-into-hash (-> (-> any/c any/c any/c) reducer?)]
-  [combine-into-mutable-hash (-> (-> any/c any/c any/c) reducer?)]
+  [into-hash (reducer/c entry? immutable-hash?)]
+  [into-mutable-hash (reducer/c entry? mutable-hash?)]
+  [combine-into-hash
+   (-> (-> any/c any/c any/c) (reducer/c entry? immutable-hash?))]
+  [combine-into-mutable-hash
+   (-> (-> any/c any/c any/c) (reducer/c entry? mutable-hash?))]
   [hash-set-entry (-> immutable-hash? entry? immutable-hash?)]
   [hash-set-entry! (-> mutable-hash? entry? void?)]
   [hash-key-set (-> immutable-hash? set?)]

--- a/private/hash.scrbl
+++ b/private/hash.scrbl
@@ -2,6 +2,7 @@
 
 @(require (for-label racket/base
                      racket/contract/base
+                     racket/sequence
                      racket/set
                      rebellion/base/immutable-string
                      rebellion/collection/entry

--- a/private/hash.scrbl
+++ b/private/hash.scrbl
@@ -37,8 +37,8 @@
  respectively. Both predicates imply @racket[immutable-hash?].}
 
 @deftogether[[
- @defthing[into-hash reducer?]
- @defthing[into-mutable-hash reducer?]]]{
+ @defthing[into-hash (reducer/c entry? immutable-hash?)]
+ @defthing[into-mutable-hash (reducer/c entry? mutable-hash?)]]]{
  A pair of @tech{reducers} that build either an immutable hash table or a
  mutable hash table from a sequence of @tech{entries}. Duplicate keys are not
  allowed, and attempting to reduce a sequence containing duplicate keys will
@@ -52,9 +52,10 @@
             (immutable-string-length str))))}
 
 @deftogether[[
- @defproc[(combine-into-hash [value-combiner (-> any/c any/c any/c)]) reducer?]
+ @defproc[(combine-into-hash [value-combiner (-> any/c any/c any/c)])
+          (reducer/c entry? immutable-hash?)]
  @defproc[(combine-into-mutable-hash [value-combiner (-> any/c any/c any/c)])
-          reducer?]]]{
+          (reducer/c entry? mutable-hash?)]]]{
  Constructs a @tech{reducer} that combines a sequence of @tech{entries} into
  either an immutable hash table or a mutable hash table, respectively. Values
  for duplicate keys are combined using @racket[value-combiner].

--- a/private/impersonation.rkt
+++ b/private/impersonation.rkt
@@ -7,7 +7,8 @@
   [impersonator-property-hash/c flat-contract?]
   [function-impersonate
    (->* (procedure?)
-        (#:guard (or/c procedure? #f)
+        (#:arguments-guard (or/c procedure? #f)
+         #:results-guard (or/c procedure? #f)
          #:properties impersonator-property-hash/c
          #:application-marks (and/c hash? immutable?)
          #:chaperone? boolean?)
@@ -17,7 +18,12 @@
         (#:properties impersonator-property-hash/c #:chaperone? boolean?)
         any/c)]))
 
-(require racket/bool)
+(require racket/bool
+         rebellion/private/strict-cond)
+
+(module+ test
+  (require rackunit
+           rebellion/private/static-name))
 
 ;@------------------------------------------------------------------------------
 
@@ -29,11 +35,13 @@
               [element (in-list (list k v))])
     element))
 
-(define (function-impersonate function
-                              #:guard [guard #f]
-                              #:properties [props (hash)]
-                              #:application-marks [marks (hash)]
-                              #:chaperone? [chaperone? (false? guard)])
+(define (function-impersonate
+         function
+         #:arguments-guard [arguments-guard #f]
+         #:results-guard [results-guard #f]
+         #:properties [props (hash)]
+         #:application-marks [marks (hash)]
+         #:chaperone? [chaperone? (false? arguments-guard)])
   (define impersonator-factory
     (if chaperone? chaperone-procedure impersonate-procedure))
   (define prop-args (impersonator-properties->positional-arguments props))
@@ -43,7 +51,21 @@
          [element
           (in-list (list impersonator-prop:application-mark (cons k v)))])
       element))
-  (apply impersonator-factory function guard (append prop-args mark-args)))
+  (apply impersonator-factory
+         function
+         (function-application-guard arguments-guard results-guard)
+         (append prop-args mark-args)))
+
+(define (function-application-guard guard result-guard)
+  (strict-cond
+    [(false? result-guard) guard]
+    [(false? guard) (λ xs (apply values (cons result-guard xs)))]
+    [else
+     (λ xs
+       (call-with-values
+        (λ () (apply guard xs))
+        (λ guarded (apply values (cons result-guard guarded)))))]))
+    
 
 (define (struct-impersonate instance type
                             #:properties [props (hash)]
@@ -52,3 +74,46 @@
     (if chaperone? chaperone-struct impersonate-struct))
   (define prop-args (impersonator-properties->positional-arguments props))
   (apply impersonator-factory instance type prop-args))
+
+(module+ test
+  (test-case (name-string function-impersonate)
+    (test-case "argument guard"
+      (define arg1 (box #f))
+      (define arg2 (box #f))
+      (define (guard x y)
+        (set-box! arg1 x)
+        (set-box! arg2 y)
+        (values x y))
+      (define impersonated (function-impersonate expt #:arguments-guard guard))
+      (check-equal? (impersonated 2 5) 32)
+      (check-equal? (unbox arg1) 2)
+      (check-equal? (unbox arg2) 5))
+
+    (test-case "result guard"
+      (define result (box #f))
+      (define (guard x)
+        (set-box! result x)
+        x)
+      (define impersonated (function-impersonate + #:results-guard guard))
+      (check-equal? (impersonated 1 2 3) 6)
+      (check-equal? (unbox result) 6))
+
+    (test-case "argument and result guards"
+      (define arg1 (box #f))
+      (define arg2 (box #f))
+      (define result (box #f))
+      (define (argument-guard x y)
+        (set-box! arg1 x)
+        (set-box! arg2 y)
+        (values x y))
+      (define (result-guard x)
+        (set-box! result x)
+        x)
+      (define impersonated
+        (function-impersonate expt
+                              #:arguments-guard argument-guard
+                              #:results-guard result-guard))
+      (check-equal? (impersonated 2 5) 32)
+      (check-equal? (unbox arg1) 2)
+      (check-equal? (unbox arg2) 5)
+      (check-equal? (unbox result) 32))))

--- a/private/impersonation.rkt
+++ b/private/impersonation.rkt
@@ -41,7 +41,8 @@
          #:results-guard [results-guard #f]
          #:properties [props (hash)]
          #:application-marks [marks (hash)]
-         #:chaperone? [chaperone? (false? arguments-guard)])
+         #:chaperone?
+         [chaperone? (and (false? arguments-guard) (false? results-guard))])
   (define impersonator-factory
     (if chaperone? chaperone-procedure impersonate-procedure))
   (define prop-args (impersonator-properties->positional-arguments props))
@@ -87,7 +88,10 @@
       (define impersonated (function-impersonate expt #:arguments-guard guard))
       (check-equal? (impersonated 2 5) 32)
       (check-equal? (unbox arg1) 2)
-      (check-equal? (unbox arg2) 5))
+      (check-equal? (unbox arg2) 5)
+      (check-equal? impersonated expt)
+      (check-true (impersonator-of? impersonated expt))
+      (check-false (chaperone-of? impersonated expt)))
 
     (test-case "result guard"
       (define result (box #f))
@@ -96,7 +100,10 @@
         x)
       (define impersonated (function-impersonate + #:results-guard guard))
       (check-equal? (impersonated 1 2 3) 6)
-      (check-equal? (unbox result) 6))
+      (check-equal? (unbox result) 6)
+      (check-equal? impersonated +)
+      (check-true (impersonator-of? impersonated +))
+      (check-false (chaperone-of? impersonated +)))
 
     (test-case "argument and result guards"
       (define arg1 (box #f))
@@ -116,4 +123,7 @@
       (check-equal? (impersonated 2 5) 32)
       (check-equal? (unbox arg1) 2)
       (check-equal? (unbox arg2) 5)
-      (check-equal? (unbox result) 32))))
+      (check-equal? (unbox result) 32)
+      (check-equal? impersonated expt)
+      (check-true (impersonator-of? impersonated expt))
+      (check-false (chaperone-of? impersonated expt)))))

--- a/private/keyset-reducer.rkt
+++ b/private/keyset-reducer.rkt
@@ -6,7 +6,7 @@
  for/keyset
  for*/keyset
  (contract-out
-  [into-keyset reducer?]))
+  [into-keyset (reducer/c keyword? keyset?)]))
 
 (require (for-syntax racket/base)
          rebellion/collection/keyset/low-dependency

--- a/private/keyset.scrbl
+++ b/private/keyset.scrbl
@@ -101,7 +101,8 @@ at compile-time.
    (keyset-remove fruits '#:banana))}
 
 @defproc[(in-keyset [keys keyset?]) (sequence/c keyword?)]{
- Returns a @tech/reference{sequence} of the keywords in @racket[keys], in ascending order.
+ Returns a @tech/reference{sequence} of the keywords in @racket[keys], in
+ ascending order.
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -151,14 +152,14 @@ at compile-time.
    #:eval (make-evaluator) #:once
    (list->keyset (list '#:banana '#:orange '#:orange '#:apple '#:grape)))}
 
-@defproc[(keyset->set [keys keyset?]) (immutable-set/c keyword?)]{
+@defproc[(keyset->set [keys keyset?]) (set/c keyword?)]{
  Converts @racket[keys] into a plain @tech/reference{set} of keywords.
 
  @(examples
    #:eval (make-evaluator) #:once
    (keyset->set (keyset #:red #:blue #:green #:yellow)))}
 
-@defproc[(set->keyset [kw-set (immutable-set/c keyword?)]) keyset?]{
+@defproc[(set->keyset [kw-set (set/c keyword?)]) keyset?]{
  Sorts @racket[kw-set], returning a @tech{keyset}.
 
  @(examples

--- a/private/list.rkt
+++ b/private/list.rkt
@@ -15,9 +15,9 @@
   [list-ref-safe (-> list? natural? option?)]
   [list-contains? (-> list? any/c boolean?)]
   [list-reverse (-> list? list?)]
-  [into-list reducer?]
-  [into-reversed-list reducer?]
-  [append-into-list reducer?]))
+  [into-list (reducer/c any/c list?)]
+  [into-reversed-list (reducer/c any/c list?)]
+  [append-into-list (reducer/c list? list?)]))
 
 (require racket/math
          rebellion/base/option

--- a/private/list.scrbl
+++ b/private/list.scrbl
@@ -25,8 +25,8 @@ lists. Additionally, it provides a few utilities for integrating lists with some
 of Rebellion's standard abstractions, such as @tech{reducers}. No attempt is
 made to wrap every possible list-related function or rename every export of
 @racketmodname[racket/list], as many of these operations are better expressed in
-terms of generic @tech/reference{sequences}, @racket[for] loops, and @tech{reducers}
-rather than lists specifically.
+terms of generic @tech/reference{sequences}, @racket[for] loops, @tech{
+ reducers}, and @tech{transducers} rather than lists specifically.
 
 For the purposes of this library, "list" means "proper list". Improper lists
 (such as those constructed by @racket[list*]) are a poor fit for most
@@ -95,8 +95,8 @@ list-related tasks and should be avoided in favor of other data structures.
  Returns @racket[#t] if @racket[lst] contains @racket[v], returns @racket[#f]
  otherwise. This operation takes time linear in the length of the list. Lists
  are not designed for efficient membership queries, so if you find yourself
- using this function consider whether you could use a @tech/reference{set} or @tech{
-  multiset} instead.
+ using this function consider whether you could use a @tech/reference{set} or
+ @tech{multiset} instead.
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -126,25 +126,25 @@ list-related tasks and should be avoided in favor of other data structures.
  intended, and the latter unnecessarily requires the reader to understand the
  subtleties of quotation.}
 
-@defthing[into-list reducer?]{
+@defthing[into-list (reducer/c any/c list?)]{
  A @tech{reducer} that collects elements into a list, preserving their order.
 
  @(examples
    #:eval (make-evaluator) #:once
    (reduce into-list 1 2 3 4 5))}
 
-@defthing[into-reversed-list reducer?]{
+@defthing[into-reversed-list (reducer/c any/c list?)]{
  A @tech{reducer} that collects elements into a list, in reverse order. This can
  be more efficient than @racket[into-list]. This function should be preferred
  over @racket[in-list] when the order of the returned list doesn't matter, but
- in these cases strongly consider using @tech/reference{sets} or @tech{multisets} instead
- of lists to make the lack of order explicit.
+ in these cases strongly consider using @tech/reference{sets} or @tech{
+  multisets} instead of lists to make the lack of order explicit.
 
  @(examples
    #:eval (make-evaluator) #:once
    (reduce into-reversed-list 1 2 3 4 5))}
 
-@defthing[append-into-list reducer?]{
+@defthing[append-into-list (reducer/c list? list?)]{
  A @tech{reducer} that collects a sequence of lists into a single list, in the
  same manner as @racket[list-append].
 

--- a/private/multidict.rkt
+++ b/private/multidict.rkt
@@ -31,7 +31,7 @@
   [empty-multidict? predicate/c]
   [nonempty-multidict? predicate/c]
   [in-multidict-entries (-> multidict? (sequence/c entry?))]
-  [into-multidict reducer?]))
+  [into-multidict (reducer/c entry? multidict?)]))
 
 (require (for-syntax racket/base)
          racket/list

--- a/private/multidict.scrbl
+++ b/private/multidict.scrbl
@@ -292,6 +292,6 @@ interface is based on a flattened collection of key-value pairs.
  Iterates like @racket[for*], but collects each @tech{entry} returned by
  @racket[body] into a @tech{multidict}.}
 
-@defthing[into-multidict reducer?]{
+@defthing[into-multidict (reducer/c entry? multidict?)]{
  A @tech{reducer} that reduces a sequence of @tech{entries} into a
  @tech{multidict}.}

--- a/private/multidict.scrbl
+++ b/private/multidict.scrbl
@@ -4,6 +4,7 @@
                      racket/contract/base
                      racket/math
                      racket/sequence
+                     racket/set
                      rebellion/collection/entry
                      rebellion/collection/list
                      rebellion/collection/multidict

--- a/private/multidict.scrbl
+++ b/private/multidict.scrbl
@@ -3,6 +3,7 @@
 @(require (for-label racket/base
                      racket/contract/base
                      racket/math
+                     racket/sequence
                      rebellion/collection/entry
                      rebellion/collection/list
                      rebellion/collection/multidict

--- a/private/multidict.scrbl
+++ b/private/multidict.scrbl
@@ -9,6 +9,7 @@
                      rebellion/collection/list
                      rebellion/collection/multidict
                      rebellion/collection/multiset
+                     rebellion/collection/set
                      rebellion/streaming/reducer)
           (submod rebellion/private/scribble-evaluator-factory doc)
           (submod rebellion/private/scribble-cross-document-tech doc)
@@ -190,9 +191,9 @@ interface is based on a flattened collection of key-value pairs.
                "The Hulk" 'marvel
                "Captain Marvel" 'marvel)))}
 
-@defproc[(multidict-entries [dict multidict?]) (immutable-set/c entry?)]{
- Returns the set of @tech{entries} in @racket[dict]. Note that this is
- @bold{not} a @tech{multiset}, because for each key the collection of values
+@defproc[(multidict-entries [dict multidict?]) (set/c entry?)]{
+ Returns the (immutable) set of @tech{entries} in @racket[dict]. Note that this
+ is @bold{not} a @tech{multiset}, because for each key the collection of values
  mapped by that key contains no duplicates.
 
  @(examples
@@ -253,7 +254,7 @@ interface is based on a flattened collection of key-value pairs.
 @section{Multidict Conversions}
 
 @defproc[(multidict->hash [dict multidict?])
-         (hash/c any/c nonempty-set? #:immutable? #t)]{
+         (hash/c any/c nonempty-set? #:immutable #t)]{
  Converts @racket[dict] into a hash table from keys to (nonempty) sets of
  values.
 

--- a/private/multiset.rkt
+++ b/private/multiset.rkt
@@ -23,7 +23,7 @@
   [sequence->multiset (-> multiset-coercible-sequence/c multiset?)]
   [empty-multiset multiset?]
   [in-multiset (-> multiset? sequence?)]
-  [into-multiset reducer?]))
+  [into-multiset (reducer/c any/c multiset?)]))
 
 (require (for-syntax racket/base)
          racket/hash

--- a/private/multiset.scrbl
+++ b/private/multiset.scrbl
@@ -3,6 +3,7 @@
 @(require (for-label racket/base
                      racket/contract/base
                      racket/math
+                     racket/sequence
                      rebellion/collection/multiset
                      rebellion/streaming/reducer)
           (submod rebellion/private/scribble-evaluator-factory doc)

--- a/private/multiset.scrbl
+++ b/private/multiset.scrbl
@@ -18,9 +18,9 @@
 @title{Multisets}
 @defmodule[rebellion/collection/multiset]
 
-A @deftech{multiset} is an unordered collection, like a @tech/reference{set}, except it
-can contain duplicate elements. Elements are always compared with @racket[
- equal?].
+A @deftech{multiset} is an unordered collection, like a @tech/reference{set},
+except it can contain duplicate elements. Elements are always compared with
+@racket[equal?].
 
 @defproc[(multiset? [v any/c]) boolean?]{
  A predicate for @tech{multisets}.}
@@ -154,8 +154,8 @@ the modified multiset.
 @section{Multiset Iteration and Comprehension}
 
 @defproc[(in-multiset [set multiset?]) sequence?]{
- Returns a @tech/reference{sequence} that iterates over the elements of @racket[set],
- including duplicates.
+ Returns a @tech/reference{sequence} that iterates over the elements of @racket[
+ set], including duplicates.
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -163,7 +163,7 @@ the modified multiset.
    (for ([v (in-multiset set)])
      (displayln v)))}
 
-@defthing[into-multiset reducer?]{
+@defthing[into-multiset (reducer/c any/c multiset?)]{
  A @tech{reducer} that collects elements into a @tech{multiset}.
 
  @(examples

--- a/private/record.scrbl
+++ b/private/record.scrbl
@@ -3,6 +3,7 @@
 @(require (for-label racket/base
                      racket/contract/base
                      racket/math
+                     rebellion/collection/immutable-vector
                      rebellion/collection/keyset
                      rebellion/collection/record)
           (submod rebellion/private/scribble-evaluator-factory doc)
@@ -18,8 +19,8 @@
 @defmodule[rebellion/collection/record]
 
 A @deftech{record} is a collection of name-value mappings, each which is called
-a @deftech{record field}. The name of a field is a @tech/reference{keyword}. Records
-support constant-time lookup of field values by name.
+a @deftech{record field}. The name of a field is a @tech/reference{keyword}.
+Records support constant-time lookup of field values by name.
 
 Records are similar to hash tables, except keys @emph{must} be keywords. Records
 are less dynamic than general-purpose hash tables, but their specialized nature

--- a/private/reducer.scrbl
+++ b/private/reducer.scrbl
@@ -3,6 +3,7 @@
 @(require (for-label racket/base
                      racket/bool
                      racket/contract/base
+                     racket/contract/region
                      racket/math
                      racket/sequence
                      racket/vector
@@ -22,6 +23,7 @@
 @(define make-evaluator
    (make-module-sharing-evaluator-factory
     #:public (list 'racket/bool
+                   'racket/contract/region
                    'racket/sequence
                    'racket/vector
                    'rebellion/base/comparator
@@ -67,7 +69,7 @@ before the sequence is fully consumed.
    (reduce-all into-product (in-range 1 20))
    (reduce-all into-count (in-hash-values (hash 'a 1 'b 2 'c 3 'd 4))))}
 
-@defthing[into-sum reducer?]{
+@defthing[into-sum (reducer/c number? number?)]{
  A @tech{reducer} that reduces a sequence of numbers into their sum with
  @racket[+].
 
@@ -77,7 +79,7 @@ before the sequence is fully consumed.
    (reduce into-sum)
    (reduce-all into-sum (in-range 10000)))}
 
-@defthing[into-product reducer?]{
+@defthing[into-product (reducer/c number? number?)]{
  A @tech{reducer} that reduces a sequence of numbers into their product with
  @racket[*].
 
@@ -87,7 +89,7 @@ before the sequence is fully consumed.
    (reduce into-product)
    (reduce-all into-product (in-range 1 20)))}
 
-@defthing[into-count reducer?]{
+@defthing[into-count (reducer/c any/c number?)]{
  A @tech{reducer} that ignores the specific elements it reduces and returns only
  a count of how many elements were reduced.
 
@@ -96,7 +98,7 @@ before the sequence is fully consumed.
    (reduce into-count 'a 'b 'c)
    (reduce-all into-count "hello world"))}
 
-@defthing[into-first reducer?]{
+@defthing[into-first (reducer/c any/c option?)]{
  A @tech{reducer} that returns an @tech{option} of the first element it reduces,
  or @racket[absent] if the reduced sequence is empty.
 
@@ -104,7 +106,7 @@ before the sequence is fully consumed.
    #:eval (make-evaluator) #:once
    (reduce-all into-first "hello world"))}
 
-@defthing[into-last reducer?]{
+@defthing[into-last (reducer/c any/c option?)]{
  A @tech{reducer} that returns an @tech{option} of the last element it reduces,
  or @racket[absent] if the reduced sequence is empty.
 
@@ -112,7 +114,7 @@ before the sequence is fully consumed.
    #:eval (make-evaluator) #:once
    (reduce-all into-last "hello world"))}
 
-@defproc[(into-nth [n natural?]) reducer?]{
+@defproc[(into-nth [n natural?]) (reducer/c any/c option?)]{
  Constructs a @tech{reducer} that returns the @racket[n]th element it reduces,
  wrapped in an @tech{option} value. If the reduced sequence has fewer than
  @racket[n] elements, the reducer returns @racket[absent].
@@ -123,7 +125,7 @@ before the sequence is fully consumed.
    (reduce-all (into-nth 20) "hello world")
    (reduce-all (into-nth 0) "hello world"))}
 
-@defproc[(into-index-of [v any/c]) reducer?]{
+@defproc[(into-index-of [v any/c]) (reducer/c any/c (option/c natural?))]{
  Constructs a @tech{reducer} that searches the reduced sequence for @racket[v]
  and returns an @tech{option} wrapping the position of @racket[v] in the
  sequence. If the reduced sequence does not contain @racket[v], then the reducer
@@ -134,7 +136,8 @@ before the sequence is fully consumed.
    (reduce-all (into-index-of #\e) "battery")
    (reduce-all (into-index-of #\o) "cat"))}
 
-@defproc[(into-index-where [pred predicate/c]) reducer?]{
+@defproc[(into-index-where [pred predicate/c])
+         (reducer/c any/c (option/c natural?))]{
  Constructs a @tech{reducer} that searches the reduced sequence for the first
  value for which @racket[pred] returns true, then returns an @tech{option}
  wrapping the position of that value. If the reduced sequence does not contain
@@ -145,7 +148,7 @@ before the sequence is fully consumed.
    (reduce-all (into-index-where char-whitespace?) "hello world")
    (reduce-all (into-index-where char-numeric?) "goodbye world"))}
 
-@defproc[(into-any-match? [pred predicate/c]) reducer?]{
+@defproc[(into-any-match? [pred predicate/c]) (reducer/c any/c boolean?)]{
  Constructs a @tech{reducer} that searches the reduced sequence for at least one
  element that satisfies @racket[pred], returning true if an element is found and
  returning false otherwise. If the sequence is empty, then the reducer returns
@@ -157,7 +160,7 @@ before the sequence is fully consumed.
    (reduce-all (into-any-match? char-numeric?) "hello world")
    (reduce-all (into-any-match? char-whitespace?) ""))}
 
-@defproc[(into-all-match? [pred predicate/c]) reducer?]{
+@defproc[(into-all-match? [pred predicate/c]) (reducer/c any/c boolean?)]{
  Constructs a @tech{reducer} that returns true if every element in the reduced
  sequence satisfies @racket[pred], otherwise false is returned. If the sequence
  is empty, then the reducer returns true.
@@ -168,7 +171,7 @@ before the sequence is fully consumed.
    (reduce-all (into-all-match? char-alphabetic?) "hello world")
    (reduce-all (into-all-match? char-alphabetic?) ""))}
 
-@defproc[(into-none-match? [pred predicate/c]) reducer?]{
+@defproc[(into-none-match? [pred predicate/c]) (reducer/c any/c boolean?)]{
  Constructs a @tech{reducer} that returns true if no element in the reduced
  sequence satisfies @racket[pred], otherwise false is returned. If the sequence
  is empty, then the reducer returns true.
@@ -179,7 +182,7 @@ before the sequence is fully consumed.
    (reduce-all (into-none-match? char-whitespace?) "hello world")
    (reduce-all (into-none-match? char-whitespace?) ""))}
 
-@defproc[(into-for-each [handler (-> any/c void?)]) reducer?]{
+@defproc[(into-for-each [handler (-> any/c void?)]) (reducer/c any/c void?)]{
  Constructs a @tech{reducer} that calls @racket[handler] on each element for its
  side effects. The reduction result of the returned reducer is always @racket[
  (void)].
@@ -191,10 +194,10 @@ before the sequence is fully consumed.
 @deftogether[[
  @defproc[(into-max [comparator comparator? real<=>]
                     [#:key key-function (-> any/c any/c) values])
-          reducer?]
+          (reducer/c any/c option?)]
  @defproc[(into-min [comparator comparator? real<=>]
                     [#:key key-function (-> any/c any/c) values])
-          reducer?]]]{
+          (reducer/c any/c option?)]]]{
  Constructs a @tech{reducer} that searches the reduced sequence for either the
  greatest element or the least element, respectively. If @racket[key-function]
  is provided, it is used to extract the compared value from each element.
@@ -212,14 +215,16 @@ before the sequence is fully consumed.
 
    (reduce (into-min string<=>) "goodbye" "cruel" "world")
 
-   (define-record-type gemstone (color weight))
+   (eval:no-prompt
+    (define-record-type gemstone (color weight)))
+   
    (reduce (into-max #:key gemstone-weight)
            (gemstone #:color 'red #:weight 5)
            (gemstone #:color 'blue #:weight 7)
            (gemstone #:color 'green #:weight 3)
            (gemstone #:color 'yellow #:weight 7)))}
 
-@defthing[into-string reducer?]{
+@defthing[into-string (reducer/c char? immutable-string?)]{
  A @tech{reducer} that collects a sequence of individual characters into an
  immutable string.
 
@@ -228,8 +233,8 @@ before the sequence is fully consumed.
    (reduce into-string #\h #\e #\l #\l #\o)
    (reduce-all into-string (list #\a #\b #\c)))}
 
-@defthing[into-line reducer?]{
- Like @racket[into-string], but stops the reduction as soon as the @racket[
+@defthing[into-line (reducer/c char? immutable-string?)]{
+ Like @racket[into-string], but stops the reduction as soon as a @racket[
  #\newline] character is encountered.
 
  @(examples
@@ -244,7 +249,7 @@ Refrigerator"))}
           [#:before-first before-first immutable-string? ""]
           [#:before-last before-last immutable-string? sep]
           [#:after-last after-last immutable-string? ""])
-         reducer?]{
+         (reducer/c immutable-string? immutable-string?)]{
  Constructs a @tech{reducer} that joins a sequence of immutable strings into a
  single immutable string, in the same manner as @racket[string-join].
 
@@ -463,6 +468,28 @@ reducers with increasing power and complexity:
      (make-reducer-based-for-comprehensions #'into-sum))
    (for/sum ([str (in-list (list "apple" "orange" "banana" "grapefruit"))])
      (string-length str)))}
+
+@section{Reducer Contracts}
+
+@defproc[(reducer/c [domain-contract contract?] [range-contract contract?])
+         contract?]{
+ A @tech/reference{contract combinator} for @tech{reducers}. Returns a contract
+ that enforces that the contracted value is a reducer and wrap the reducer to
+ enforce @racket[domain-contract] and @racket[range-contract]. Every reduced
+ element is checked with @racket[domain-contract], and every reduction result is
+ checked with @racket[range-contract]. If both @racket[domain-contract] and
+ @racket[range-contract] are @tech/reference{chaperone contracts}, then the
+ returned contract is as well.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (eval:no-prompt
+    (define/contract into-string-append
+      (reducer/c string? string?)
+      (make-fold-reducer string-append "" #:name 'into-string-append)))
+
+   (reduce into-string-append "Red" "Blue" "Green")
+   (eval:error (reduce into-string-append "Red" 42 "Green")))}
 
 @section{Reducer Chaperones and Impersonators}
 

--- a/private/set.rkt
+++ b/private/set.rkt
@@ -4,8 +4,8 @@
 
 (provide
  (contract-out
-  [into-set reducer?]
-  [into-mutable-set reducer?]))
+  [into-set (reducer/c any/c set?)]
+  [into-mutable-set (reducer/c any/c set-mutable?)]))
 
 (require racket/set
          rebellion/streaming/reducer)

--- a/private/set.rkt
+++ b/private/set.rkt
@@ -4,8 +4,11 @@
 
 (provide
  (contract-out
+  [empty-set? predicate/c]
+  [nonempty-set? predicate/c]
+  [mutable-set? predicate/c]
   [into-set (reducer/c any/c set?)]
-  [into-mutable-set (reducer/c any/c set-mutable?)]))
+  [into-mutable-set (reducer/c any/c mutable-set?)]))
 
 (require racket/set
          rebellion/streaming/reducer)
@@ -17,6 +20,9 @@
 ;@------------------------------------------------------------------------------
 
 (define empty-set (set))
+
+(define (empty-set? v) (and (set? v) (set-empty? v)))
+(define (nonempty-set? v) (and (set? v) (not (set-empty? v))))
 
 (define (mutable-set? v) (set-mutable? v))
 

--- a/private/set.scrbl
+++ b/private/set.scrbl
@@ -23,8 +23,8 @@
 @defmodule[rebellion/collection/set]
 
 @deftogether[[
- @defthing[into-set reducer?]
- @defthing[into-mutable-set reducer?]]]{
+ @defthing[into-set (reducer/c any/c set?)]
+ @defthing[into-mutable-set (reducer/c any/c set-mutable?)]]]{
  @tech{Reducers} that collect elements of the reduced sequence into either an
  immutable @tech/reference{set} or a mutable set, respectively.
 

--- a/private/set.scrbl
+++ b/private/set.scrbl
@@ -22,6 +22,18 @@
 @title{Sets}
 @defmodule[rebellion/collection/set]
 
+@defthing[empty-set emtpy-set?]{
+ The empty immutable @tech{set}.}
+
+@defproc[(empty-set? [v any/c]) boolean?]{
+ A predicate for empty immutable sets. Implies @racket[set?].}
+
+@defproc[(nonempty-set? [v any/c]) boolean?]{
+ A predicate for nonempty immutable sets. Implies @racket[set?].}
+
+@defproc[(mutable-set? [v any/c]) boolean?]{
+ A predicate for mutable sets. Equivalent to @racket[set-mutable?].}
+
 @deftogether[[
  @defthing[into-set (reducer/c any/c set?)]
  @defthing[into-mutable-set (reducer/c any/c set-mutable?)]]]{

--- a/private/table.rkt
+++ b/private/table.rkt
@@ -16,7 +16,7 @@
   [table-rows-ref (-> table? natural? record?)]
   [table-size (-> table? natural?)]
   [in-table (-> table? (sequence/c record?))]
-  [into-table reducer?]))
+  [into-table (reducer/c record? table?)]))
 
 (require (for-syntax racket/base)
          racket/math

--- a/private/table.scrbl
+++ b/private/table.scrbl
@@ -5,6 +5,7 @@
                      racket/math
                      racket/sequence
                      rebellion/base/symbol
+                     rebellion/collection/immutable-vector
                      rebellion/collection/record
                      rebellion/collection/table
                      rebellion/streaming/reducer)

--- a/private/table.scrbl
+++ b/private/table.scrbl
@@ -137,7 +137,7 @@ is significant and duplicate rows are allowed. Tables implement the
  tab]. Tables already implement the sequence interface, but using this function
  in a @racket[for] form may perform better and give clearer error messages.}
 
-@defthing[into-table reducer?]{
+@defthing[into-table (reducer/c record? table?)]{
  A @tech{reducer} that reduces @tech{records} into a @tech{table}, in the same
  manner as @racket[for/table].
 

--- a/private/vector.rkt
+++ b/private/vector.rkt
@@ -4,16 +4,20 @@
 
 (provide
  (contract-out
-  [into-vector (->* () (#:size (or/c natural? +inf.0)) reducer?)]
-  [into-mutable-vector (->* () (#:size (or/c natural? +inf.0)) reducer?)]
+  [mutable-vector? predicate/c]
+  [into-vector
+   (->* () (#:size (or/c natural? +inf.0)) (reducer/c any/c immutable-vector?))]
+  [into-mutable-vector
+   (->* () (#:size (or/c natural? +inf.0)) (reducer/c any/c mutable-vector?))]
   [sequence->vector
    (-> (or/c vector? list? set? (sequence/c any/c))
-       (and/c vector? immutable?))]))
+       immutable-vector?)]))
 
 (require racket/math
          racket/sequence
          racket/set
          rebellion/collection/vector/builder
+         rebellion/collection/immutable-vector
          rebellion/private/static-name
          rebellion/streaming/reducer)
 
@@ -22,6 +26,8 @@
            rackunit))
 
 ;@------------------------------------------------------------------------------
+
+(define (mutable-vector? v) (and (vector? v) (not (immutable? v))))
 
 (define into-unlimited-vector
   (make-effectful-fold-reducer vector-builder-add

--- a/private/vector.scrbl
+++ b/private/vector.scrbl
@@ -21,7 +21,11 @@
 @title{Vectors}
 @defmodule[rebellion/collection/vector]
 
-@defproc[(into-vector [#:size size (or/c natural? +inf.0) +inf.0]) reducer?]{
+@defproc[(mutable-vector? [v any/c]) boolean?]{
+ A predicate for mutable vectors. Implies @racket[vector?].}
+
+@defproc[(into-vector [#:size size (or/c natural? +inf.0) +inf.0])
+         (reducer/c any/c immutable-vector?)]{
  Constructs a @tech{reducer} that collects at most @racket[size] elements of a
  sequence into an immutable vector.
 
@@ -32,7 +36,7 @@
               #:into (into-vector #:size 5)))}
 
 @defproc[(into-mutable-vector [#:size size (or/c natural? +inf.0) +inf.0])
-         reducer?]{
+         (reducer/c any/c mutable-vector?)]{
  Constructs a @tech{reducer} that collects at most @racket[size] elements of a
  sequence into a mutable vector.
 


### PR DESCRIPTION
Closes #194. Also makes significant improvements to the collection APIs by using reducer contracts instead of just the `reducer?` predicate.

I expect this to significantly decrease the performance of reducers. A solvable problem, but an unfortunate one.