### PR TITLE
Add variant contracts

### DIFF
--- a/private/contract-projection.rkt
+++ b/private/contract-projection.rkt
@@ -34,6 +34,6 @@
 (define (assert-satisfies v predicate blame #:missing-party missing-party)
   (unless (predicate v)
     (raise-blame-error blame #:missing-party missing-party v
-                       '(expected: "~e" given: "~e")
-                       predicate
+                       '(expected: "~a" given: "~e")
+                       (object-name predicate)
                        v)))

--- a/private/reducer.rkt
+++ b/private/reducer.rkt
@@ -17,14 +17,14 @@
         (#:name (or/c interned-symbol? #f))
         reducer?)]
   [make-reducer
-   (->* (#:starter (-> variant?)
-         #:consumer (-> any/c any/c variant?)
+   (->* (#:starter (-> reduction-state/c)
+         #:consumer (-> any/c any/c reduction-state/c)
          #:finisher (-> any/c any/c)
          #:early-finisher (-> any/c any/c))
         (#:name (or/c interned-symbol? #f))
         reducer?)]
-  [reducer-starter (-> reducer? (-> variant?))]
-  [reducer-consumer (-> reducer? (-> any/c any/c variant?))]
+  [reducer-starter (-> reducer? (-> reduction-state/c))]
+  [reducer-consumer (-> reducer? (-> any/c any/c reduction-state/c))]
   [reducer-finisher (-> reducer? (-> any/c any/c))]
   [reducer-early-finisher (-> reducer? (-> any/c any/c))]
   [reduce (-> reducer? any/c ... any/c)]
@@ -101,6 +101,8 @@
 
 ;@------------------------------------------------------------------------------
 ;; Core APIs
+
+(define reduction-state/c (variant/c #:consume any/c #:early-finish any/c))
 
 (define-object-type reducer (starter consumer finisher early-finisher)
   #:constructor-name constructor:reducer)

--- a/private/transducer-base.rkt
+++ b/private/transducer-base.rkt
@@ -49,8 +49,14 @@
 
 ;@------------------------------------------------------------------------------
 
-(define transduction-state/c variant?)
-(define half-closed-transduction-state/c variant?)
+(define transduction-state/c
+  (variant/c #:consume any/c
+             #:emit any/c
+             #:half-closed-emit any/c
+             #:finish any/c))
+
+(define half-closed-transduction-state/c
+  (variant/c #:half-closed-emit any/c #:finish any/c))
 
 (define-tuple-type emission (state value))
 (define-tuple-type half-closed-emission (state value))
@@ -98,7 +104,7 @@
                      #:name (object-name transducer)))
 
   (object-impersonate impersonated-without-props descriptor:transducer
-                         #:properties properties))
+                      #:properties properties))
 
 (define ((transducer-consumer-guard domain-guard) state element)
   (values state (domain-guard element)))


### PR DESCRIPTION
Also, use them in transducers and reducers.

Closes #170, obsoletes #303.

Will likely cause transducers and reducers to take a performance hit (again). Alas.