### PR TITLE
Tweak the docs for define-enum-type

### DIFF
--- a/private/enum-type.scrbl
+++ b/private/enum-type.scrbl
@@ -3,6 +3,7 @@
 @(require (for-label racket/base
                      racket/contract/base
                      racket/contract/region
+                     racket/match
                      rebellion/base/symbol
                      rebellion/type/enum
                      rebellion/type/tuple)
@@ -13,6 +14,7 @@
    (make-module-sharing-evaluator-factory
     #:public (list 'racket/contract/base
                    'racket/contract/region
+                   'racket/match
                    'rebellion/type/enum
                    'rebellion/type/tuple)
     #:private (list 'racket/base)))
@@ -32,13 +34,12 @@ related constants, such as primary colors and directions.
 
    (define/contract (point-move pt dir amount)
      (-> point? direction? real? point?)
-     (define x (point-x pt))
-     (define y (point-y pt))
-     (cond
-       [(equal? dir up) (point x (+ y amount))]
-       [(equal? dir down) (point x (- y amount))]
-       [(equal? dir left) (point (- x amount) y)]
-       [(equal? dir right) (point (+ x amount) y)])))
+     (match-define (point x y) pt)
+     (match dir
+       [(== up) (point x (+ y amount))]
+       [(== down) (point x (- y amount))]
+       [(== left) (point (- x amount) y)]
+       [(== right) (point (+ x amount) y)])))
   
   (point-move (point 2 2) up 5)
   (point-move (point 1 4) left 10)
@@ -50,7 +51,7 @@ related constants, such as primary colors and directions.
              (code:line #:predicate-name predicate-id)
              (code:line #:property-maker property-maker)])
  #:contracts ([property-maker
-               (-> uninitialized-singleton-descriptor?
+               (-> uninitialized-enum-descriptor?
                    (listof (cons/c struct-type-property? any/c)))])]{
  Creates an @tech{enum type} named @racket[id]. Each @racket[case-id] is bound
  to a constant, and @racket[predicate-id] is bound to a predicate that returns
@@ -60,8 +61,25 @@ related constants, such as primary colors and directions.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (define-enum-type suit (diamonds clubs hearts spades))
+   (eval:no-prompt
+    (define-enum-type suit (diamonds clubs hearts spades))
+    (define-enum-type face (jack queen king))
+    (define-tuple-type card (type suit))
 
-   (suit? diamonds)
-   (suit? 42)
-   spades)}
+    (define king-of-clubs (card king clubs)))
+
+   (card-type king-of-clubs)
+   (card-suit king-of-clubs)
+
+   (eval:no-prompt
+    (define/contract (card-value c)
+      (-> card? (integer-in 1 13))
+      (match (card-type c)
+        [(? number? x) x]
+        [(== jack) 11]
+        [(== queen) 12]
+        [(== king) 13])))
+
+   (card-value king-of-clubs)
+   (card-value (card 7 spades))
+   (card-value (card jack hearts)))}


### PR DESCRIPTION
Partially addresses #431. Doc changes include:

- Using pattern matching instead of cond in examples.
- Fixing a doc error in the #:property-maker argument.
- Addding more example code.