### PR TITLE
Fix enum type descriptor docs and explain descriptor initialization

### DIFF
--- a/private/enum-type.scrbl
+++ b/private/enum-type.scrbl
@@ -83,3 +83,12 @@ related constants, such as primary colors and directions.
    (card-value king-of-clubs)
    (card-value (card 7 spades))
    (card-value (card jack hearts)))}
+
+@defproc[(enum-descriptor? [v any/c]) boolean?]{
+ A predicate for enum @tech{type descriptors}.}
+
+@defproc[(initialized-enum-descriptor? [v any/c]) boolean?]{
+ A predicate for initialized enum @tech{type descriptors}.}
+
+@defproc[(uninitialized-enum-descriptor? [v any/c]) boolean?]{
+ A predicate for uninitialized enum @tech{type descriptors}.}

--- a/private/type.scrbl
+++ b/private/type.scrbl
@@ -106,6 +106,21 @@ distinct implementations that are not @racket[equal?] to each other, meaning
 that the @racketmodname[rebellion/type] modules create @deftech{generative
  types}.
 
+Type descriptors may be @emph{uninitialized}. An uninitialized type descriptor
+cannot be used to create or interact with instances of the type until after
+initialization is complete. Uninitialized type descriptors are fairly rare: they
+can only be obtained via the @racket[#:property-maker] mechanism for specifying
+structure type properties of created types. This is because the property-making
+function needs to receive the type descriptor in order to return implementations
+of type properties, but this happens @emph{before} the type is created. Property
+makers can't use the descriptor's constructor and accessor immediately, but they
+can refer to them in implementations of properties such as
+@racket[prop:custom-write] (since by the time the constructor or accessor is
+actually used, the type is created and the descriptor is initialized). This
+delayed initialization step is necessary to allow property makers to be defined
+without mutual recursion and in separate modules from the type definitions
+they're used for, allowing reuse of generic property makers.
+
 @subsection{Defining Types}
 
 Each @racketmodfont{rebellion/type/}@racket[_kind] module provides a


### PR DESCRIPTION
Closes #434. Also tried to give an explanation of why descriptors can be uninitialized in the first place. The text is a pretty rough draft, but it's better than nothing.