### PR TITLE
Add tuple type bindings

### DIFF
--- a/private/enum-type-descriptor.rkt
+++ b/private/enum-type-descriptor.rkt
@@ -103,7 +103,7 @@
   (maker type predicate selector discriminator))
 
 (define (enum-type->tuple-type type)
-  (tuple-type (enum-type-name type) 1
+  (tuple-type (enum-type-name type) (list 'index)
               #:predicate-name (enum-type-predicate-name type)
               #:constructor-name (enum-type-selector-name type)))
 

--- a/private/media.rkt
+++ b/private/media.rkt
@@ -157,11 +157,8 @@
 ;@------------------------------------------------------------------------------
 ;; media
 
-(define type:media (tuple-type 'media 2))
-(define index:media:type 0)
-(define index:media:bytes 1)
+(define type:media (tuple-type 'media (list 'type 'bytes)))
 (define descriptor:media (make-tuple-implementation type:media))
-
 (define media (tuple-descriptor-constructor descriptor:media))
 (define media? (tuple-descriptor-predicate descriptor:media))
 
@@ -169,11 +166,10 @@
 ;;   definition macros so this isn't necessary anymore
 (define media-get-type
   (procedure-rename
-   (make-tuple-field-accessor descriptor:media index:media:type 'type)
+   (make-tuple-field-accessor descriptor:media 0)
    'media-get-type))
 
-(define media-bytes
-  (make-tuple-field-accessor descriptor:media index:media:bytes 'bytes))
+(define media-bytes (make-tuple-field-accessor descriptor:media 1))
 
 (module+ test
   (test-case "media"

--- a/private/object-type-descriptor.rkt
+++ b/private/object-type-descriptor.rkt
@@ -137,7 +137,8 @@
 
 (define (object-type->tuple-type type)
   (tuple-type (object-type-name type)
-              (object-type-size type)
+              (for/list ([field (object-type-fields type)])
+                (string->symbol (keyword->string field)))
               #:predicate-name (object-type-predicate-name type)
               #:constructor-name (object-type-constructor-name type)
               #:accessor-name (object-type-accessor-name type)))

--- a/private/record-type-descriptor.rkt
+++ b/private/record-type-descriptor.rkt
@@ -78,7 +78,8 @@
 
 (define (record-type->tuple-type type)
   (tuple-type (record-type-name type)
-              (keyset-size (record-type-fields type))
+              (for/list ([field (in-keyset (record-type-fields type))])
+                (string->symbol (keyword->string field)))
               #:predicate-name (record-type-predicate-name type)
               #:constructor-name (record-type-constructor-name type)
               #:accessor-name (record-type-accessor-name type)))

--- a/private/record-type.rkt
+++ b/private/record-type.rkt
@@ -40,9 +40,10 @@
   (define-record-type id:id fields:record-fields
     (~alt
      (~optional (~and #:omit-root-binding omit-root-binding-kw))
-     (~optional (~seq #:predicate-name predicate:id)
-                #:defaults ([predicate (format-id #'id "~a?" #'id #:subs? #t)])
-                #:name "#:predicate-name option")
+     (~optional
+      (~seq #:predicate-name predicate:id)
+      #:defaults ([predicate (format-id #'id "~a?" #'id #:subs? #t)])
+      #:name "#:predicate-name option")
      (~optional
       (~seq #:descriptor-name descriptor:id)
       #:defaults ([descriptor (format-id #'id "descriptor:~a" #'id #:subs? #t)])
@@ -60,10 +61,11 @@
      (~optional
       (~seq #:pattern-name pattern:id)
       #:defaults ([pattern (format-id #'id "pattern:~a" #'id #:subs? #t)])
-      #:name "#:constructor-name option")
-     (~optional (~seq #:property-maker prop-maker:expr)
-                #:defaults ([prop-maker #'default-record-properties])
-                #:name "#:property-maker option"))
+      #:name "#:pattern-name option")
+     (~optional
+      (~seq #:property-maker prop-maker:expr)
+      #:defaults ([prop-maker #'default-record-properties])
+      #:name "#:property-maker option"))
     ...)
   #:with (field-accessor ...)
   (for/list ([field-id-stx (in-syntax #'(fields.id ...))])

--- a/private/singleton-type-descriptor.rkt
+++ b/private/singleton-type-descriptor.rkt
@@ -64,7 +64,7 @@
     (prop-maker
      (uninitialized-singleton-descriptor #:type type #:predicate predicate)))
   (define type/tuple
-    (tuple-type (singleton-type-name type) 0
+    (tuple-type (singleton-type-name type) (list)
                 #:predicate-name (singleton-type-predicate-name type)))
   (define descriptor
     (make-tuple-implementation type/tuple

--- a/private/tuple-type-base.rkt
+++ b/private/tuple-type-base.rkt
@@ -5,83 +5,59 @@
 (provide
  (contract-out
   [tuple-type
-   (->* (interned-symbol? natural?)
+   (->* (interned-symbol? (sequence/c interned-symbol?))
         (#:predicate-name (or/c interned-symbol? #f)
          #:constructor-name (or/c interned-symbol? #f)
          #:accessor-name (or/c interned-symbol? #f))
         tuple-type?)]
   [tuple-type? (-> any/c boolean?)]
+  [tuple-type-name (-> tuple-type? interned-symbol?)]
+  [tuple-type-fields
+   (-> tuple-type? (vectorof interned-symbol? #:immutable #t))]
   [tuple-type-accessor-name (-> tuple-type? interned-symbol?)]
   [tuple-type-constructor-name (-> tuple-type? interned-symbol?)]
-  [tuple-type-name (-> tuple-type? interned-symbol?)]
   [tuple-type-predicate-name (-> tuple-type? interned-symbol?)]
   [tuple-type-size (-> tuple-type? natural?)]))
 
-(require racket/math
-         racket/struct
+(require racket/list
+         racket/math
+         racket/sequence
          racket/syntax
-         rebellion/base/symbol
-         rebellion/collection/keyset/low-dependency
-         rebellion/equal+hash/struct
-         rebellion/private/struct-definition-util
-         rebellion/type/struct)
+         rebellion/base/symbol)
 
 ;@------------------------------------------------------------------------------
 
-(define (make-struct-constructor-style-custom-write descriptor)
-  (define type-name (struct-descriptor-name descriptor))
-  (define size
-    (+ (struct-descriptor-mutable-fields descriptor)
-       (struct-descriptor-immutable-fields descriptor)
-       (struct-descriptor-auto-fields descriptor)))
-  (define accessor (struct-descriptor-accessor descriptor))
-  (make-constructor-style-printer
-   (λ (this) type-name)
-   (λ (this) (build-list size (λ (pos) (accessor this pos))))))
-
-(define (make-transparent-style-properties descriptor)
-  (define equal+hash (make-struct-equal+hash descriptor))
-  (define custom-write (make-struct-constructor-style-custom-write descriptor))
-  (list (cons prop:equal+hash equal+hash)
-        (cons prop:custom-write custom-write)))
-
-;@------------------------------------------------------------------------------
-
-(define fields:tuple-type
-  (keyset #:name
-          #:size
-          #:predicate-name
-          #:constructor-name
-          #:accessor-name))
-
-(define descriptor:tuple-type
-  (make-struct-implementation
-   #:name 'tuple-type
-   #:immutable-fields (keyset-size fields:tuple-type)
-   #:constructor-name 'constructor:tuple-type
-   #:property-maker make-transparent-style-properties))
-
-(define tuple-type? (struct-descriptor-predicate descriptor:tuple-type))
-
-(define constructor:tuple-type
-  (struct-descriptor-constructor descriptor:tuple-type))
+(struct tuple-type (name fields predicate-name constructor-name accessor-name)
+  #:transparent
+  #:omit-define-syntaxes
+  #:constructor-name constructor:tuple-type)
 
 (define (tuple-type
          name
-         size
+         fields
          #:predicate-name [predicate-name* #f]
          #:constructor-name [constructor-name* #f]
          #:accessor-name [accessor-name* #f])
+  (define field-vector
+    (vector->immutable-vector (for/vector ([field fields]) field)))
+  (check-field-names-unique field-vector)
   (define predicate-name
     (or predicate-name* (default-tuple-predicate-name name)))
   (define constructor-name (or constructor-name* name))
   (define accessor-name (or accessor-name* (default-tuple-accessor-name name)))
   (constructor:tuple-type
-   name size predicate-name constructor-name accessor-name))
+   name field-vector predicate-name constructor-name accessor-name))
 
-(define-struct-field-accessors tuple-type
-  (name size predicate-name constructor-name accessor-name)
-  #:descriptor descriptor:tuple-type)
+(define (tuple-type-size type)
+  (vector-length (tuple-type-fields type)))
+
+(define (check-field-names-unique names)
+  (define duplicate (check-duplicates (vector->list names)))
+  (when duplicate
+    (raise-arguments-error
+     'tuple-type
+     "duplicate field names are not allowed in tuple types"
+     "duplicate name" duplicate)))
 
 (define (default-tuple-predicate-name type-name)
   (format-symbol "~a?" type-name))

--- a/private/tuple-type-binding-test.rkt
+++ b/private/tuple-type-binding-test.rkt
@@ -1,0 +1,46 @@
+#lang racket/base
+
+(module+ test
+  (require (for-syntax rebellion/type/tuple/binding)
+           rackunit
+           rebellion/type/tuple
+           syntax/parse/define))
+
+;@------------------------------------------------------------------------------
+
+(module+ test
+  (define-tuple-type widget (price weight description))
+
+  (test-case "basic tuple-id parsing"
+    (define-simple-macro (tester :tuple-id) 'success!)
+    (check-equal? (tester widget) 'success!))
+  
+  (test-case "tuple-id.name"
+    (define-simple-macro (tester tuple:tuple-id) tuple.name)
+    (check-equal? (tester widget) 'widget))
+
+  (test-case "tuple-id.field-name"
+    (define-simple-macro (tester tuple:tuple-id) (list tuple.field-name ...))
+    (check-equal? (tester widget) (list 'price 'weight 'description)))
+
+  (test-case "tuple-id.descriptor"
+    (define-simple-macro (tester tuple:tuple-id) tuple.descriptor)
+    (check-equal? (tester widget) descriptor:widget))
+
+  (test-case "tuple-id.predicate"
+    (define-simple-macro (tester tuple:tuple-id) tuple.predicate)
+    (check-equal? (tester widget) widget?))
+
+  (test-case "tuple-id.constructor"
+    (define-simple-macro (tester tuple:tuple-id) tuple.constructor)
+    (check-equal? (tester widget) widget))
+
+  (test-case "tuple-id.accessor"
+    (define-simple-macro (tester tuple:tuple-id) tuple.accessor)
+    (check-equal? (tester widget) accessor:widget))
+
+  (test-case "tuple-id.field-accessor"
+    (define-simple-macro (tester tuple:tuple-id)
+      (list tuple.field-accessor ...))
+    (check-equal?
+     (tester widget) (list widget-price widget-weight widget-description))))

--- a/private/tuple-type-binding.rkt
+++ b/private/tuple-type-binding.rkt
@@ -1,0 +1,106 @@
+#lang racket/base
+
+(require racket/contract/base)
+
+(provide
+ tuple-id
+ (contract-out
+  [tuple-binding? predicate/c]
+  [tuple-binding-type (-> tuple-binding? tuple-type?)]
+  [tuple-binding-descriptor (-> tuple-binding? identifier?)]
+  [tuple-binding-predicate (-> tuple-binding? identifier?)]
+  [tuple-binding-constructor (-> tuple-binding? identifier?)]
+  [tuple-binding-accessor (-> tuple-binding? identifier?)]
+  [tuple-binding-field-accessors
+   (-> tuple-binding? (vectorof identifier? #:immutable #t))]))
+
+(module+ private-constructor
+  (provide
+   (contract-out
+    [tuple-binding
+     (-> #:type tuple-type?
+         #:descriptor identifier?
+         #:predicate identifier?
+         #:constructor identifier?
+         #:accessor identifier?
+         #:field-accessors (sequence/c identifier?)
+         #:pattern identifier?
+         #:macro (-> syntax? syntax?)
+         tuple-binding?)])))
+
+(require (for-template racket/base
+                       racket/match)
+         racket/sequence
+         racket/syntax
+         rebellion/type/tuple/base
+         syntax/parse)
+
+;@------------------------------------------------------------------------------
+
+(struct tuple-binding
+  (type
+   descriptor
+   predicate
+   constructor
+   accessor
+   field-accessors
+   pattern
+   macro)
+  #:omit-define-syntaxes
+  #:constructor-name constructor:tuple-binding
+
+  #:property prop:match-expander
+  (λ (this stx)
+    (define/with-syntax pattern (tuple-binding-pattern this))
+    (syntax-parse stx #:track-literals
+      [(_ . body) (quasisyntax/loc stx (pattern . body))]))
+
+  #:property prop:procedure (λ (this stx) ((tuple-binding-macro this) stx)))
+
+(define (tuple-binding
+         #:type type
+         #:descriptor descriptor
+         #:predicate predicate
+         #:constructor constructor
+         #:accessor accessor
+         #:field-accessors field-accessors
+         #:pattern pattern
+         #:macro macro)
+  (define field-accessor-vector
+    (vector->immutable-vector
+     (for/vector ([field-accessor field-accessors]) field-accessor)))
+  (constructor:tuple-binding
+   type
+   descriptor
+   predicate
+   constructor
+   accessor
+   field-accessor-vector
+   pattern
+   macro))
+
+(define-syntax-class tuple-id
+  #:attributes
+  (type
+   name
+   [field-name 1]
+   descriptor
+   predicate
+   constructor
+   accessor
+   [field-accessor 1])
+
+  (pattern binding
+    #:declare binding (static tuple-binding? "a static tuple-binding? value")
+    #:cut
+    #:attr type (tuple-binding-type (attribute binding.value))
+    #:with name #`'#,(tuple-type-name (attribute type))
+    #:with (field-name ...)
+    (for/list ([field-name (in-vector (tuple-type-fields (attribute type)))])
+      #`'#,field-name)
+    #:with descriptor (tuple-binding-descriptor (attribute binding.value))
+    #:with predicate (tuple-binding-predicate (attribute binding.value))
+    #:with constructor (tuple-binding-constructor (attribute binding.value))
+    #:with accessor (tuple-binding-accessor (attribute binding.value))
+    #:with (field-accessor ...)
+    (sequence->list (tuple-binding-field-accessors (attribute binding.value)))))

--- a/private/tuple-type-descriptor.rkt
+++ b/private/tuple-type-descriptor.rkt
@@ -15,7 +15,6 @@
          [pos (desc)
               (and/c natural?
                      (</c (tuple-type-size (tuple-descriptor-type desc))))])
-        ([field-name symbol?])
         [_ (desc) (-> (tuple-descriptor-predicate desc) any/c)])]
   [tuple-descriptor? (-> any/c boolean?)]
   [tuple-descriptor-accessor (-> tuple-descriptor? (-> any/c natural? any/c))]
@@ -217,11 +216,11 @@
    #:constructor (get-constructor descriptor)
    #:accessor (get-accessor descriptor)))
 
-(define (make-tuple-field-accessor descriptor pos [field-name* #f])
+(define (make-tuple-field-accessor descriptor pos)
   (define type (tuple-descriptor-type descriptor))
   (define accessor (tuple-descriptor-accessor descriptor))
   (define name (tuple-type-name type))
-  (define field-name (or field-name* (string->symbol (format "field~a" pos))))
+  (define field-name (vector-ref (tuple-type-fields type) pos))
   (define field-accessor-name (string->symbol (format "~a-~a" name field-name)))
   (procedure-rename (λ (this) (accessor this pos)) field-accessor-name))
 
@@ -236,12 +235,12 @@
 
 (module+ test
   (test-case "make-tuple-implementation"
-    (define point-type (tuple-type 'point 2))
+    (define point-type (tuple-type 'point (list 'x 'y)))
     (define point-descriptor (make-tuple-implementation point-type))
     (define point (tuple-descriptor-constructor point-descriptor))
     (define point? (tuple-descriptor-predicate point-descriptor))
-    (define point-x (make-tuple-field-accessor point-descriptor 0 'x))
-    (define point-y (make-tuple-field-accessor point-descriptor 1 'y))
+    (define point-x (make-tuple-field-accessor point-descriptor 0))
+    (define point-y (make-tuple-field-accessor point-descriptor 1))
     (define p (point 42 1000))
     (check-pred point? p)
     (check-equal? p (point 42 1000))

--- a/private/tuple-type.rkt
+++ b/private/tuple-type.rkt
@@ -4,7 +4,11 @@
 
 (require (for-syntax racket/base
                      racket/sequence
-                     racket/syntax)
+                     racket/syntax
+                     (submod rebellion/private/tuple-type-binding
+                             private-constructor)
+                     rebellion/type/tuple/base
+                     syntax/transformer)
          racket/match
          rebellion/type/tuple/base
          rebellion/type/tuple/descriptor
@@ -22,16 +26,31 @@
     (~alt
      (~optional (~and #:omit-root-binding omit-root-binding-kw))
      (~optional
+      (~seq #:descriptor-name descriptor:id)
+      #:defaults ([descriptor (format-id #'id "descriptor:~a" #'id #:subs? #t)])
+      #:name "#:descriptor-name option")
+     (~optional
+      (~seq #:predicate-name predicate:id)
+      #:defaults ([predicate (format-id #'id "~a?" #'id #:subs? #t)])
+      #:name "#:predicate-name option")
+     (~optional
       (~seq #:constructor-name constructor:id)
       #:defaults
-      ([constructor (format-id #'id "constructor:~a" #'id #:subs? #t)]))
-     (~optional (~seq #:predicate-name predicate:id)
-                #:defaults ([predicate (format-id #'id "~a?" #'id #:subs? #t)]))
-     (~optional (~seq #:property-maker property-maker:expr)
-                #:defaults ([property-maker #'default-tuple-properties]))
+      ([constructor (format-id #'id "constructor:~a" #'id #:subs? #t)])
+      #:name "#:constructor-name option")
+     (~optional
+      (~seq #:accessor-name accessor:id)
+      #:defaults
+      ([accessor (format-id #'id "accessor:~a" #'id #:subs? #t)])
+      #:name "#:accessor-name option")
      (~optional
       (~seq #:pattern-name pattern:id)
-      #:defaults ([pattern (format-id #'id "pattern:~a" #'id #:subs? #t)])))
+      #:defaults ([pattern (format-id #'id "pattern:~a" #'id #:subs? #t)])
+      #:name "#:pattern-name option")
+     (~optional
+      (~seq #:property-maker property-maker:expr)
+      #:defaults ([property-maker #'default-tuple-properties])
+      #:name "#:property-maker option"))
     ...)
   #:do [(define size (length (syntax->list #'(field ...))))]
   #:with (field-accessor ...)
@@ -41,10 +60,20 @@
   #:with root-binding
   (if (attribute omit-root-binding-kw)
       #'(begin)
-      #'(...
-         (define-match-expander id
-           (syntax-parser [(_ rest ...) #'(pattern rest ...)])
-           (make-rename-transformer #'constructor))))
+      #'(define-syntax id
+          (tuple-binding
+           #:type
+           (tuple-type
+            'id (list 'field ...)
+            #:constructor-name 'constructor
+            #:predicate-name 'predicate)
+           #:descriptor #'descriptor
+           #:predicate #'predicate
+           #:constructor #'constructor
+           #:accessor #'accessor
+           #:field-accessors (list #'field-accessor ...)
+           #:pattern #'pattern
+           #:macro (make-variable-like-transformer #'constructor))))
   (begin
     (define descriptor
       (make-tuple-implementation
@@ -54,6 +83,7 @@
        #:property-maker property-maker))
     (define constructor (tuple-descriptor-constructor descriptor))
     (define predicate (tuple-descriptor-predicate descriptor))
+    (define accessor (tuple-descriptor-accessor descriptor))
     (define field-accessor
       (make-tuple-field-accessor descriptor field-position))
     ...

--- a/private/tuple-type.rkt
+++ b/private/tuple-type.rkt
@@ -34,7 +34,6 @@
       #:defaults ([pattern (format-id #'id "pattern:~a" #'id #:subs? #t)])))
     ...)
   #:do [(define size (length (syntax->list #'(field ...))))]
-  #:with quoted-size #`(quote #,size)
   #:with (field-accessor ...)
   (for/list ([field-id (in-syntax #'(field ...))])
     (format-id field-id "~a-~a" #'id field-id #:subs? #t))
@@ -49,14 +48,14 @@
   (begin
     (define descriptor
       (make-tuple-implementation
-       (tuple-type 'id quoted-size
+       (tuple-type 'id (list 'field ...)
                    #:constructor-name 'constructor
                    #:predicate-name 'predicate)
        #:property-maker property-maker))
     (define constructor (tuple-descriptor-constructor descriptor))
     (define predicate (tuple-descriptor-predicate descriptor))
     (define field-accessor
-      (make-tuple-field-accessor descriptor field-position 'field))
+      (make-tuple-field-accessor descriptor field-position))
     ...
     (define-match-expander pattern
       (syntax-parser

--- a/private/tuple-type.scrbl
+++ b/private/tuple-type.scrbl
@@ -111,28 +111,32 @@ represent a single logical thing, and there is an obvious order to those pieces.
 
 @defproc[
  (tuple-type [name interned-symbol?]
-             [size natural?]
+             [fields (sequence/c interned-symbol?)]
              [#:predicate-name predicate-name (or/c interned-symbol? #f) #f]
              [#:constructor-name constructor-name (or/c interned-symbol? #f) #f]
              [#:accessor-name accessor-name (or/c interned-symbol? #f) #f])
  tuple-type?]{
- Constructs a @tech{tuple type} of size @racket[size] and named @racket[name].
- The optional @racket[predicate-name], @racket[constructor-name], and @racket[
- accessor-name] arguments control the result of @racket[object-name] on the
- functions implementing the type. If not provided, @racket[predicate-name]
- defaults to @racket[name]@racketidfont{?}, @racket[constructor-name] defaults
- to @racket[name], and @racket[accessor-name] defaults to @racket[
- name]@racketidfont{-ref}. Two tuple types constructed with the same arguments
- are @racket[equal?]. To make an implementation of a tuple type, see @racket[
- make-tuple-implementation].}
+ Constructs a @tech{tuple type} named @racket[name] and with fields named
+ @racket[fields]. The optional @racket[predicate-name],
+ @racket[constructor-name], and @racket[accessor-name] arguments control the
+ result of @racket[object-name] on the functions implementing the type. If not
+ provided, @racket[predicate-name] defaults to @racket[name]@racketidfont{?},
+ @racket[constructor-name] defaults to @racket[name], and @racket[accessor-name]
+ defaults to @racket[name]@racketidfont{-ref}. Two tuple types constructed with
+ the same arguments are @racket[equal?]. To make an implementation of a tuple
+ type, see @racket[make-tuple-implementation].}
 
 @deftogether[[
  @defproc[(tuple-type-name [type tuple-type?]) interned-symbol?]
- @defproc[(tuple-type-size [type tuple-type?]) natural?]
+ @defproc[(tuple-type-fields [type tuple-type?])
+          (vectorof interned-symbol? #:immutable #t)]
  @defproc[(tuple-type-predicate-name [type tuple-type?]) interned-symbol?]
  @defproc[(tuple-type-constructor-name [type tuple-type?]) interned-symbol?]
  @defproc[(tuple-type-accessor-name [type tuple-type?]) interned-symbol?]]]{
  Accessors for the various fields of a @tech{tuple type}.}
+
+@defproc[(tuple-type-size [type tuple-type?]) natural?]{
+ Returns the number of fields in @racket[type].}
 
 @section{Tuple Type Descriptors}
 
@@ -183,25 +187,21 @@ represent a single logical thing, and there is an obvious order to those pieces.
  @(examples
    #:eval (make-evaluator) #:once
    (define point-descriptor
-     (make-tuple-implementation (tuple-type 'point 2)))
+     (make-tuple-implementation (tuple-type 'point (list 'x 'y))))
    (define point (tuple-descriptor-constructor point-descriptor))
-   (define point-x (make-tuple-field-accessor point-descriptor 0 'x))
-   (define point-y (make-tuple-field-accessor point-descriptor 1 'y))
+   (define point-x (make-tuple-field-accessor point-descriptor 0))
+   (define point-y (make-tuple-field-accessor point-descriptor 1))
    (point 42 888)
    (point-x (point 42 888))
    (point-y (point 42 888)))}
 
 @defproc[
  (make-tuple-field-accessor [descriptor tuple-descriptor?]
-                            [pos natural?]
-                            [name (or/c interned-symbol? #f)
-                             (symbol->string (format "field~a" pos))])
+                            [pos natural?])
  (-> (tuple-descriptor-predicate descriptor) any/c)]{
  Builds a field accessor function that returns the @racket[pos] field of
- instances of the @tech{tuple type} implemented by @racket[descriptor]. If
- @racket[name] is provided, it is used to derive the name of the function for
- debugging purposes. See @racket[make-tuple-implementation] for usage
- examples.}
+ instances of the @tech{tuple type} implemented by @racket[descriptor]. See
+ @racket[make-tuple-implementation] for usage examples.}
 
 @defproc[
  (default-tuple-properties [descriptor uninitialized-tuple-descriptor?])

--- a/private/wrapper-type-descriptor.rkt
+++ b/private/wrapper-type-descriptor.rkt
@@ -68,7 +68,7 @@
          #:property-maker [prop-maker default-wrapper-properties]
          #:inspector [inspector (current-inspector)])
   (define tuple-impl-type
-    (tuple-type (wrapper-type-name type) 1
+    (tuple-type (wrapper-type-name type) (list 'value)
                 #:predicate-name (wrapper-type-predicate-name type)
                 #:constructor-name (wrapper-type-constructor-name type)))
   (define (tuple-impl-prop-maker tuple-impl)

--- a/type/tuple/binding.rkt
+++ b/type/tuple/binding.rkt
@@ -1,0 +1,2 @@
+#lang reprovide
+rebellion/private/tuple-type-binding


### PR DESCRIPTION
Needs docs. Also includes a breaking change to `tuple-type` in order to include field names in the type. Part of #179.