### PR TITLE
Implement singleton type bindings

### DIFF
--- a/private/singleton-type-binding-test.rkt
+++ b/private/singleton-type-binding-test.rkt
@@ -1,0 +1,32 @@
+#lang racket/base
+
+(module+ test
+  (require (for-syntax rebellion/type/singleton/binding)
+           rackunit
+           rebellion/type/singleton
+           syntax/parse/define))
+
+;@------------------------------------------------------------------------------
+
+(module+ test
+  (define-singleton-type infinity)
+
+  (test-case "basic singleton-id parsing"
+    (define-simple-macro (tester :singleton-id) 'success!)
+    (check-equal? (tester infinity) 'success!))
+  
+  (test-case "singleton-id.name"
+    (define-simple-macro (tester singleton:singleton-id) singleton.name)
+    (check-equal? (tester infinity) 'infinity))
+
+  (test-case "singleton-id.descriptor"
+    (define-simple-macro (tester singleton:singleton-id) singleton.descriptor)
+    (check-equal? (tester infinity) descriptor:infinity))
+
+  (test-case "singleton-id.predicate"
+    (define-simple-macro (tester singleton:singleton-id) singleton.predicate)
+    (check-equal? (tester infinity) infinity?))
+
+  (test-case "singleton-id.instance"
+    (define-simple-macro (tester singleton:singleton-id) singleton.instance)
+    (check-equal? (tester infinity) infinity)))

--- a/private/singleton-type-binding.rkt
+++ b/private/singleton-type-binding.rkt
@@ -1,0 +1,58 @@
+#lang racket/base
+
+(require racket/contract/base)
+
+(provide
+ singleton-id
+ (contract-out
+  [singleton-binding? predicate/c]
+  [singleton-binding-type (-> singleton-binding? singleton-type?)]
+  [singleton-binding-descriptor (-> singleton-binding? identifier?)]
+  [singleton-binding-predicate (-> singleton-binding? identifier?)]
+  [singleton-binding-instance (-> singleton-binding? identifier?)]))
+
+(module+ private-constructor
+  (provide
+   (contract-out
+    [singleton-binding
+     (-> #:type singleton-type?
+         #:descriptor identifier?
+         #:predicate identifier?
+         #:instance identifier?
+         #:macro (-> syntax? syntax?)
+         singleton-binding?)])))
+
+(require (for-template racket/base)
+         racket/sequence
+         racket/syntax
+         rebellion/type/singleton/base
+         syntax/parse)
+
+;@------------------------------------------------------------------------------
+
+(struct singleton-binding
+  (type descriptor predicate instance macro)
+  #:omit-define-syntaxes
+  #:constructor-name constructor:singleton-binding
+  #:property prop:procedure (λ (this stx) ((singleton-binding-macro this) stx)))
+
+(define (singleton-binding
+         #:type type
+         #:descriptor descriptor
+         #:predicate predicate
+         #:instance instance
+         #:macro macro)
+  (constructor:singleton-binding type descriptor predicate instance macro))
+
+(define-syntax-class singleton-id
+  #:attributes (type name descriptor predicate instance)
+
+  (pattern
+      (~var
+       binding (static singleton-binding? "a static singleton-binding? value"))
+    #:cut
+    #:attr type (singleton-binding-type (attribute binding.value))
+    #:with name #`'#,(singleton-type-name (attribute type))
+    #:with descriptor (singleton-binding-descriptor (attribute binding.value))
+    #:with predicate (singleton-binding-predicate (attribute binding.value))
+    #:with instance (singleton-binding-instance (attribute binding.value))))

--- a/type/singleton/binding.rkt
+++ b/type/singleton/binding.rkt
@@ -1,0 +1,2 @@
+#lang reprovide
+rebellion/private/singleton-type-binding


### PR DESCRIPTION
Part of #179. Needs docs, and the existing singleton type docs already need some work as-is. Technically backwards-incompatible as it removes the `#:type-representation-name` option from `define-singleton-type`. That feature is nearly useless anyway and it doesn't make sense when the type is constructed in both the runtime phase and the compile-time phase.