### PR TITLE
Document singleton types

### DIFF
--- a/private/enum-type.scrbl
+++ b/private/enum-type.scrbl
@@ -8,6 +8,8 @@
                      racket/match
                      rebellion/base/symbol
                      rebellion/collection/keyset
+                     rebellion/custom-write
+                     rebellion/equal+hash
                      rebellion/type/enum
                      rebellion/type/enum/binding
                      rebellion/type/tuple

--- a/private/record-type.scrbl
+++ b/private/record-type.scrbl
@@ -184,7 +184,7 @@ can access any field in the record: the per-field accessors created by
  Returns the @tech{record type} that @racket[descriptor] implements.}
 
 @defproc[(record-descriptor-predicate [descriptor record-descriptor?])
-         (-> any/c boolean?)]{
+         predicate/c]{
  Returns a predicate that returns true when given any record instance created by
  @racket[descriptor]. The predicate is specific to @racket[descriptor] --- it
  will not return true for record instances created by any other record

--- a/private/singleton-type.rkt
+++ b/private/singleton-type.rkt
@@ -21,22 +21,16 @@
 
 (begin-for-syntax
   (define-syntax-class singleton-id
-    #:attributes (default-name default-predicate-name default-descriptor-name)
+    #:attributes (default-predicate-name default-descriptor-name)
     (pattern id:id
       #:do [(define (format-singleton-id fmt)
               (format-id #'id fmt #'id #:subs? #t))]
-      #:with default-name #'id
       #:with default-predicate-name (format-singleton-id "~a?")
       #:with default-descriptor-name (format-singleton-id "descriptor:~a"))))
 
 (define-simple-macro
   (define-singleton-type id:singleton-id
     (~alt
-     (~optional
-      (~seq #:name name:id)
-      #:name "#:name option"
-      #:defaults ([name #'id.default-name]))
-
      (~optional
       (~seq #:descriptor-name descriptor:id)
       #:name "#:descriptor-name option"
@@ -61,14 +55,14 @@
   (begin
     (define descriptor
       (make-singleton-implementation
-       (singleton-type 'name #:predicate-name 'predicate)
+       (singleton-type 'id #:predicate-name 'predicate)
        #:inspector inspector
        #:property-maker prop-maker))
     (define predicate (singleton-descriptor-predicate descriptor))
     (define instance (singleton-descriptor-instance descriptor))
-    (define-syntax name
+    (define-syntax id
       (singleton-binding
-       #:type (singleton-type 'name #:predicate-name 'predicate)
+       #:type (singleton-type 'id #:predicate-name 'predicate)
        #:descriptor #'descriptor
        #:predicate #'predicate
        #:instance #'instance

--- a/private/singleton-type.scrbl
+++ b/private/singleton-type.scrbl
@@ -3,7 +3,10 @@
 @(require (for-label racket/base
                      racket/contract/base
                      racket/contract/region
+                     racket/math
                      rebellion/base/symbol
+                     rebellion/custom-write
+                     rebellion/equal+hash
                      rebellion/type/singleton)
           (submod rebellion/private/scribble-evaluator-factory doc)
           scribble/examples)
@@ -41,7 +44,6 @@ of the constant causes a compile error rather than a silent bug at runtime.
 @defform[
  (define-singleton-type id singleton-option ...)
  #:grammar ([singleton-option
-             (code:line #:value-name value-id)
              (code:line #:predicate-name predicate-id)
              (code:line #:inspector inspector)
              (code:line #:property-maker property-maker)])
@@ -52,8 +54,7 @@ of the constant causes a compile error rather than a silent bug at runtime.
  Creates a @tech{singleton type} and binds the following identifiers:
 
  @itemlist[
- @item{@racket[value-id], which defaults to @racket[id] --- the unique
-   instance of the created type.}
+ @item{@racket[id] --- the unique instance of the created type.}
 
  @item{@racket[predicate-id], which defaults to @racket[id]@racketidfont{?} ---
    a predicate that returns @racket[#t] when given the singleton instance and
@@ -66,17 +67,45 @@ of the constant causes a compile error rather than a silent bug at runtime.
    infinity
    (infinity? infinity))}
 
-@defproc[(singleton-type? [v any/c]) boolean?]
+@section{Singleton Type Information}
+
+@defproc[(singleton-type? [v any/c]) boolean?]{
+ A predicate for @tech{singleton types}.}
 
 @defproc[(singleton-type
           [name interned-symbol?]
-          [#:predicate-name pred-name (or/c interned-symbol? #f) #f])
-         singleton-type?]
+          [#:predicate-name predicate-name (or/c interned-symbol? #f) #f])
+         singleton-type?]{
+ Constructs a @tech{singleton type} named @racket[name]. The optional
+ @racket[predicate-name] argument controls the result of @racket[object-name] on
+ a predicate implementing the type. It defaults to
+ @racket[name]@racketidfont{?}. This function only constructs the information
+ representing a singleton type; to implement the type, use
+ @racket[make-singleton-implementation].}
 
-@defproc[(singleton-type-name [type singleton-type?]) interned-symbol?]
+@defproc[(singleton-type-name [type singleton-type?]) interned-symbol?]{
+ Returns the name of @racket[type].}
 
 @defproc[(singleton-type-predicate-name [type singleton-type?])
-         interned-symbol?]
+         interned-symbol?]{
+ Returns the name that should be used for predicates implementing
+ @racket[type].}
+
+@section{Singleton Type Descriptors}
+
+Singleton types are implemented using fieldless structs, where only a single
+instance of the struct can be created. The @tech{type descriptor} for a
+@tech{singleton type} provides a predicate and, if the descriptor is
+initialized, can be used to retrieve the singleton instance.
+
+@defproc[(singleton-descriptor? [v any/c]) boolean?]{
+ A predicate for singleton @tech{type descriptors}.}
+
+@defproc[(initialized-singleton-descriptor? [v any/c]) boolean?]{
+ A predicate for initialized singleton @tech{type descriptors}.}
+
+@defproc[(uninitialized-singleton-descriptor? [v any/c]) boolean?]{
+ A predicate for uninitialized singleton @tech{type descriptors}.}
 
 @defproc[(make-singleton-implementation
           [type singleton-type?]
@@ -85,20 +114,55 @@ of the constant causes a compile error rather than a silent bug at runtime.
            (-> uninitialized-singleton-descriptor?
                (listof (cons/c struct-type-property? any/c)))
            default-singleton-properties])
-         initialized-singleton-descriptor?]
+         initialized-singleton-descriptor?]{
+ Implements @racket[type] and returns a @tech{type descriptor} for the new
+ implementation. The @racket[inspector] argument behaves the same as in
+ @racket[make-struct-type], although there are no transparent or prefab
+ singleton types. The @racket[prop-maker] argument is similar to the
+ corresponding argument of @racket[make-struct-implementation]. By default,
+ singleton types are created with properties that make them print like other
+ named Racket constants --- see @racket[default-singleton-properties] for
+ details.}
 
-@defproc[(singleton-descriptor? [v any/c]) boolean?]
-
-@defproc[(initialized-singleton-descriptor? [v any/c]) boolean?]
-
-@defproc[(uninitialized-singleton-descriptor? [v any/c]) boolean?]
+@defproc[(singleton-descriptor-type [descriptor singleton-descriptor?])
+         singleton-type?]{
+ Returns the @tech{singleton type} that @racket[descriptor] implements.}
 
 @defproc[(singleton-descriptor-predicate [descriptor singleton-descriptor?])
-         predicate/c]
+         predicate/c]{
+ Returns a predicate that returns true when given the singleton instance created
+ by @racket[descriptor]. The predicate is specific to @racket[descriptor] --- it
+ will not return true for singleton instances created by any other singleton
+ descriptors, even if they're different implementations of the same singleton
+ type as @racket[descriptor]. This is because singleton types are
+ @tech{nominal types}.}
 
 @defproc[(singleton-descriptor-instance
           [descriptor initialized-singleton-descriptor?])
-         (singleton-descriptor-predicate descriptor)]
+         (singleton-descriptor-predicate descriptor)]{
+ Returns the instance of the singleton type implemented by @racket[descriptor].}
 
 @defproc[(default-singleton-properties [descriptor singleton-descriptor?])
-         (listof (cons/c struct-type-property? any/c))]
+         (listof (cons/c struct-type-property? any/c))]{
+ Returns implementations of @racket[prop:equal+hash],
+ @racket[prop:custom-write], and @racket[prop:object-name] suitable for most
+ @tech{singleton types}. The default implementation of @racket[prop:equal+hash]
+ always returns true, since it's only called if two values are instances of the
+ same type and singleton types only have one value.
+
+ This function is called by @racket[make-singleton-implementation] when no
+ @racket[_prop-maker] argument is supplied.}
+
+@defproc[(default-singleton-custom-write [descriptor singleton-descriptor?])
+         custom-write-function/c]{
+ Builds a @tech{custom write implementation} that prints singleton instances
+ created by @racket[descriptor] in a manner similar to other named Racket
+ constants such as @racket[eof]. This function is used by
+ @racket[default-singleton-properties] to implement @racket[prop:custom-write].}
+
+@defproc[(default-singleton-object-name [descriptor singleton-descriptor?])
+         (or/c natural? (-> any/c any/c))]{
+ Builds a value suitable for use with @racket[prop:object-name] that causes
+ @racket[object-name] to return the name of the instance when used on the
+ singleton instance created by @racket[descriptor]. This function is used by
+ @racket[default-singleton-properties] to implement @racket[prop:object-name].}


### PR DESCRIPTION
Also gets rid of the useless `#:name` option to `define-singleton-type`.