### PR TITLE
Store enum binding constants in a sorted vector, not a set

### DIFF
--- a/private/enum-type-binding.rkt
+++ b/private/enum-type-binding.rkt
@@ -7,7 +7,8 @@
  (contract-out
   [enum-binding? predicate/c]
   [enum-binding-type (-> enum-binding? enum-type?)]
-  [enum-binding-constants (-> enum-binding? (set/c identifier?))]
+  [enum-binding-constants
+   (-> enum-binding? (vectorof identifier? #:immutable #t))]
   [enum-binding-descriptor (-> enum-binding? identifier?)]
   [enum-binding-predicate (-> enum-binding? identifier?)]
   [enum-binding-selector (-> enum-binding? identifier?)]
@@ -45,9 +46,10 @@
                       #:predicate predicate
                       #:discriminator discriminator
                       #:selector selector)
-  (define constant-set (for/set ([c constants]) c))
+  (define constant-vector
+    (vector->immutable-vector (for/vector ([c constants]) c)))
   (constructor:enum-binding
-   type constant-set descriptor predicate discriminator selector))
+   type constant-vector descriptor predicate discriminator selector))
 
 (define-syntax-class enum-id
   #:attributes
@@ -70,10 +72,10 @@
     #:with predicate (enum-binding-predicate (attribute binding))
     #:with selector (enum-binding-selector (attribute binding))
     #:with discriminator (enum-binding-discriminator (attribute binding))
+
     #:with (constant ...)
-    (sort (sequence->list (enum-binding-constants (attribute binding)))
-          symbol<?
-          #:key syntax-e)
+    (sequence->list (enum-binding-constants (attribute binding)))
+
     #:with (constant-name ...)
     (for/list ([name (in-keyset (enum-type-constants (attribute type)))])
       #`'#,(string->symbol (keyword->string name)))))

--- a/private/enum-type.rkt
+++ b/private/enum-type.rkt
@@ -6,7 +6,6 @@
 (require (for-syntax racket/base
                      racket/provide-transform
                      racket/sequence
-                     racket/set
                      racket/syntax
                      rebellion/collection/keyset/low-dependency
                      rebellion/type/enum/base
@@ -83,10 +82,10 @@
       #:name "#:property-maker option"))
     ...)
   (begin
-    (define type
-      (enum-type 'id constants.names #:predicate-name 'predicate))
     (define descriptor
-      (make-enum-implementation type #:property-maker prop-maker))
+      (make-enum-implementation
+       (enum-type 'id constants.names #:predicate-name 'predicate)
+       #:property-maker prop-maker))
     (define predicate (enum-descriptor-predicate descriptor))
     (define discriminator (enum-descriptor-discriminator descriptor))
     (define selector (enum-descriptor-selector descriptor))
@@ -95,7 +94,7 @@
     (define-syntax id
       (enum-binding
        #:type (enum-type 'id constants.names #:predicate-name 'predicate)
-       #:constants (set #'constants.id ...)
+       #:constants (list #'constants.id ...)
        #:descriptor #'descriptor
        #:predicate #'predicate
        #:discriminator #'discriminator

--- a/private/enum-type.scrbl
+++ b/private/enum-type.scrbl
@@ -1,8 +1,6 @@
 #lang scribble/manual
 
-@(require (for-syntax racket/base
-                      racket/symbol)
-          (for-label racket/base
+@(require (for-label racket/base
                      racket/contract/base
                      racket/contract/region
                      racket/match
@@ -327,11 +325,12 @@ binding bound by @racket[define-enum-type], use the @racket[enum-id]
  binding is bound with @racket[define-syntax], this can be used at compile-time
  to obtain information about the size and names of the enum type.}
 
-@defproc[(enum-binding-constants [binding enum-binding?]) (set/c identifier?)]{
- Returns a set of identifiers bound at runtime to the constants of the enum type
- bound by @racket[binding]. When an enum type binding is bound with
+@defproc[(enum-binding-constants [binding enum-binding?])
+         (vectorof identifier? #:immutable #t)]{
+ Returns a vector of identifiers bound at runtime to the constants of the enum
+ type bound by @racket[binding]. When an enum type binding is bound with
  @racket[define-syntax], this can be used by macros to generate a list of the
- enum's constants in code.}
+ enum's constants in code. The returned identifiers are sorted alphabetically.}
 
 @defproc[(enum-binding-descriptor [binding enum-binding?]) identifier?]{
  Returns an identifier that is bound at runtime to the @tech{type descriptor}


### PR DESCRIPTION
This helps macros treat enum constants with a consistent order. Technically backwards incompatible, but this API has barely existed for more than a week or two.