### PR TITLE
Make type definition macros more consistent

### DIFF
--- a/private/enum-type-base.rkt
+++ b/private/enum-type-base.rkt
@@ -19,9 +19,9 @@
   [enum-type-size (-> enum-type? natural?)]))
 
 (require racket/math
-         racket/syntax
          rebellion/base/symbol
          rebellion/collection/keyset/low-dependency
+         rebellion/private/type-naming
          rebellion/type/tuple)
 
 ;@------------------------------------------------------------------------------
@@ -34,10 +34,10 @@
                    #:predicate-name [predicate-name* #f]
                    #:discriminator-name [discriminator-name* #f]
                    #:selector-name [selector-name* #f])
-  (define predicate-name (or predicate-name* (format-symbol "~a?" name)))
+  (define predicate-name (or predicate-name* (default-predicate-name name)))
   (define discriminator-name
-    (or discriminator-name* (format-symbol "discriminator:~a" name)))
-  (define selector-name (or selector-name* (format-symbol "selector:~a" name)))
+    (or discriminator-name* (default-discriminator-name name)))
+  (define selector-name (or selector-name* (default-selector-name name)))
   (constructor:enum-type name
                          constants
                          predicate-name

--- a/private/enum-type.rkt
+++ b/private/enum-type.rkt
@@ -6,20 +6,19 @@
 (require (for-syntax racket/base
                      racket/provide-transform
                      racket/sequence
-                     racket/syntax
                      rebellion/collection/keyset/low-dependency
-                     rebellion/type/enum/base
-                     rebellion/private/enum-type-binding
                      (submod rebellion/private/enum-type-binding
-                             private-constructor))
+                             private-constructor)
+                     rebellion/private/type-naming
+                     rebellion/type/enum/base
+                     rebellion/type/enum/binding)
          rebellion/collection/keyset/low-dependency
          rebellion/type/enum/base
          rebellion/type/enum/descriptor
          syntax/parse/define)
 
 (module+ test
-  (require (for-syntax rebellion/type/enum/binding)
-           (submod "..")
+  (require (submod "..")
            racket/format
            racket/set
            rackunit
@@ -52,53 +51,72 @@
 (define-simple-macro
   (define-enum-type id:id constants:enum-constants
     (~alt
-     (~optional
-      (~seq #:predicate-name predicate:id)
-      #:defaults
-      ([predicate (format-id #'id "~a?" #'id #:subs? #t)])
-      #:name "#:predicate-name option")
+     (~optional (~and #:omit-root-binding omit-root-binding-kw))
      
      (~optional
       (~seq #:descriptor-name descriptor:id)
-      #:defaults
-      ([descriptor (format-id #'id "descriptor:~a" #'id #:subs? #t)])
+      #:defaults ([descriptor (default-descriptor-identifier #'id)])
       #:name "#:descriptor-name option")
+
+     (~optional
+      (~seq #:predicate-name predicate:id)
+      #:defaults ([predicate (default-predicate-identifier #'id)])
+      #:name "#:predicate-name option")
      
      (~optional
       (~seq #:discriminator-name discriminator:id)
-      #:defaults
-      ([discriminator (format-id #'id "discriminator:~a" #'id #:subs? #t)])
+      #:defaults ([discriminator (default-discriminator-identifier #'id)])
       #:name "#:discriminator-name option")
      
      (~optional
       (~seq #:selector-name selector:id)
-      #:defaults
-      ([selector (format-id #'id "selector:~a" #'id #:subs? #t)])
+      #:defaults ([selector (default-selector-identifier #'id)])
       #:name "#:selector-name option")
      
+     (~optional
+      (~seq #:inspector inspector:expr)
+      #:name "#:inspector option"
+      #:defaults ([inspector #'(current-inspector)]))
+
      (~optional
       (~seq #:property-maker prop-maker:expr)
       #:defaults ([prop-maker #'default-enum-properties])
       #:name "#:property-maker option"))
     ...)
+
+  #:with root-binding
+  (if (attribute omit-root-binding-kw)
+      #'(begin)
+      #'(define-syntax id
+          (enum-binding
+           #:type
+           (enum-type
+            'id constants.names
+            #:predicate-name 'predicate
+            #:discriminator-name 'discriminator
+            #:selector-name 'selector)
+           #:constants (list #'constants.id ...)
+           #:descriptor #'descriptor
+           #:predicate #'predicate
+           #:discriminator #'discriminator
+           #:selector #'selector)))
+  
   (begin
     (define descriptor
       (make-enum-implementation
-       (enum-type 'id constants.names #:predicate-name 'predicate)
+       (enum-type
+        'id constants.names
+        #:predicate-name 'predicate
+        #:discriminator-name 'discriminator
+        #:selector-name 'selector)
+       #:inspector inspector
        #:property-maker prop-maker))
     (define predicate (enum-descriptor-predicate descriptor))
     (define discriminator (enum-descriptor-discriminator descriptor))
     (define selector (enum-descriptor-selector descriptor))
     (define constants.id (selector constants.index))
     ...
-    (define-syntax id
-      (enum-binding
-       #:type (enum-type 'id constants.names #:predicate-name 'predicate)
-       #:constants (list #'constants.id ...)
-       #:descriptor #'descriptor
-       #:predicate #'predicate
-       #:discriminator #'discriminator
-       #:selector #'selector))))
+    root-binding))
 
 (module+ test
   (test-case (name-string define-enum-type)

--- a/private/enum-type.scrbl
+++ b/private/enum-type.scrbl
@@ -58,20 +58,52 @@ related constants, such as primary colors and directions.
 
 @defform[
  (define-enum-type id (constant-id ...) enum-option ...)
- #:grammar ([enum-option
-             (code:line #:predicate-name predicate-id)
-             (code:line #:property-maker property-maker)])
- #:contracts ([property-maker
-               (-> uninitialized-enum-descriptor?
-                   (listof (cons/c struct-type-property? any/c)))])]{
- Creates an @tech{enum type} named @racket[id]. Each @racket[constant-id] is
- bound to a constant, and @racket[predicate-id] is bound to a predicate that
- returns @racket[#t] when given any of the constants and returns @racket[#f] for
- all other values. At compile-time, @racket[id] is bound to static information
- about the enum type which can be extracted with @racket[enum-id].
+ #:grammar
+ ([enum-option
+   #:omit-root-binding
+   (code:line #:descriptor-name descriptor-id)
+   (code:line #:predicate-name predicate-id)
+   (code:line #:discriminator-name discriminator-id)
+   (code:line #:selector-name selector-id)
+   (code:line #:property-maker prop-maker-expr)
+   (code:line #:inspector inspector-expr)])
+ #:contracts
+ ([prop-maker-expr
+   (-> uninitialized-enum-descriptor?
+       (listof (cons/c struct-type-property? any/c)))]
+  [inspector-expr inspector?])]{
+ Creates an @tech{enum type} named @racket[id] and binds the following
+ identifiers:
 
- If @racket[#:predicate-name] is not given, then @racket[predicate-id] defaults
- to @racket[id]@racketidfont{?}.
+ @itemlist[
+ @item{@racket[predicate-id], which defaults to @racket[id]@racketidfont{?} ---
+   a predicate function that returns @racket[#t] when given instances of the
+   created enum type and returns @racket[#f] otherwise.}
+
+ @item{Each @racket[constant-id] is bound to a constant instance of the created
+   enum type.}
+
+ @item{@racket[discriminator-id], which defaults to
+   @racketidfont{discriminator:}@racket[id] --- an @tech{enum discriminator}
+   that accepts instances of the enum type and returns the integer corresponding
+   to that instance.}
+
+ @item{@racket[selector-id], which defaults to
+   @racketidfont{selector:}@racket[id] --- an @tech{enum selector} that accepts
+   integers and returns the instance of the enum type corresponding to that
+   integer.}
+ 
+ @item{@racket[descriptor-id], which defaults to
+   @racketidfont{descriptor:}@racket[id] --- the @tech{type descriptor} for the
+   created type.}]
+
+ Additionally, unless @racket[#:omit-root-binding] is specified, the original
+ @racket[id] is bound to an @tech{enum type binding} for the created type.
+ 
+ The @racket[prop-maker-expr] is used to add structure type properties to the
+ created type, and @racket[inspector-expr] is used to determine the
+ @tech/reference{inspector} that will control the created type. See
+ @racket[make-enum-implementation] for more information about these parameters.
 
  @(examples
    #:eval (make-evaluator) #:once

--- a/private/object-type-base.rkt
+++ b/private/object-type-base.rkt
@@ -23,9 +23,9 @@
   [object-type-size (-> object-type? natural?)]))
 
 (require racket/math
-         racket/syntax
          rebellion/base/symbol
          rebellion/collection/keyset/low-dependency
+         rebellion/private/type-naming
          rebellion/type/record)
 
 ;@------------------------------------------------------------------------------
@@ -49,15 +49,10 @@
    #:name name
    #:fields all-fields
    #:name-field-position (keyset-index-of all-fields name-field)
-   #:constructor-name (or constructor-name (default-constructor-name name))
+   #:constructor-name
+   (or constructor-name (default-opaque-constructor-name name))
    #:accessor-name (or accessor-name (default-accessor-name name))
    #:predicate-name (or predicate-name (default-predicate-name name))))
-
-(define (default-constructor-name type-name)
-  (format-symbol "make-~a" type-name))
-
-(define (default-accessor-name type-name) (format-symbol "~a-ref" type-name))
-(define (default-predicate-name type-name) (format-symbol "~a?" type-name))
 
 (define (object-type-name-field type)
   (keyset-ref (object-type-fields type) (object-type-name-field-position type)))

--- a/private/object-type-binding-test.rkt
+++ b/private/object-type-binding-test.rkt
@@ -33,7 +33,7 @@
 
   (test-case "object-id.accessor"
     (define-simple-macro (tester object:object-id) object.accessor)
-    (check-equal? (tester widget) widget-ref))
+    (check-equal? (tester widget) accessor:widget))
 
   (test-case "object-id.field"
     (define-simple-macro (tester object:object-id) (list 'object.field ...))

--- a/private/object-type.scrbl
+++ b/private/object-type.scrbl
@@ -44,22 +44,25 @@ object types in Rebellion include @tech{converters}, @tech{comparators},
  (define-object-type id (field-id ...) option ...)
  #:grammar
  ([option
+   #:omit-root-binding
    (code:line #:descriptor-name descriptor-id)
    (code:line #:predicate-name predicate-id)
    (code:line #:constructor-name constructor-id)
    (code:line #:accessor-name accessor-id)
-   (code:line #:property-maker prop-maker-expr)])
+   (code:line #:property-maker prop-maker-expr)
+   (code:line #:inspector inspector-expr)])
  #:contracts
  ([prop-maker-expr
    (-> uninitialized-object-descriptor?
-       (listof (cons/c struct-type-property? any/c)))])]{
+       (listof (cons/c struct-type-property? any/c)))]
+  [inspector-expr inspector?])]{
  Creates a new @tech{object type} named @racket[id] and binds the following
  identifiers:
 
  @itemlist[
  @item{@racket[constructor-id], which defaults to
-   @racketidfont{make-}@racket[id] --- a constructor function that accepts one
-   mandatory keyword argument for each @racket[field-id] and one optional
+   @racketidfont{make-}@racket[id] --- an @tech{object constructor} that accepts
+   one mandatory keyword argument for each @racket[field-id] and one optional
    @racket[#:name] argument, then constructs an instance with the given name.
    The name argument must be either an interned symbol or false (the default).
    If the name argument is false, then the constructed instance is anonymous and
@@ -70,8 +73,27 @@ object types in Rebellion include @tech{converters}, @tech{comparators},
    created type and returns @racket[#f] otherwise.}
 
  @item{@racket[id]@racketidfont{-}@racket[field-id] for each @racket[field-id]
-   --- an accessor function that returns the value for @racket[field-id] when
-   given an instance of the created type.}]
+   (including the automatically-added @racket[_name] field) --- a field accessor
+   function that returns the value for @racket[field-id] when given an instance
+   of the created type.}
+
+ @item{@racket[accessor-id], which defaults @racketidfont{accessor:}@racket[id]
+   --- an @tech{object accessor} that accepts an instance of the created type
+   and an integer indicating which field to access, then returns the value of
+   that field.}
+
+ @item{@racket[descriptor-id], which defaults to
+   @racketidfont{descriptor:}@racket[id] --- the @tech{type descriptor} for the
+   created type.}]
+
+ Additionally, unless @racket[#:omit-root-binding] is specified, the original
+ @racket[id] is bound to an @tech{object type binding} for the created type.
+ 
+ The @racket[prop-maker-expr] is used to add structure type properties to the
+ created type, and @racket[inspector-expr] is used to determine the
+ @tech/reference{inspector} that will control the created type. See
+ @racket[make-object-implementation] for more information about these
+ parameters.
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -114,7 +136,7 @@ object types in Rebellion include @tech{converters}, @tech{comparators},
  the functions implementing the type. If not provided, @racket[predicate-name]
  defaults to @racket[name]@racketidfont{?}, @racket[constructor-name] defaults
  to @racketidfont{make-}@racket[name], and @racket[accessor-name] defaults to
- @racket[name]@racketidfont{-ref}.
+ @racketidfont{accessor:}@racket[name].
 
  This function only constructs the information representing an object type; to
  implement the type, use @racket[make-object-implementation].}

--- a/private/record-type-base.rkt
+++ b/private/record-type-base.rkt
@@ -4,11 +4,12 @@
 
 (provide
  (contract-out
-  [record-type (->* (interned-symbol? keyset?)
-                    (#:predicate-name (or/c interned-symbol? #f)
-                     #:constructor-name (or/c interned-symbol? #f)
-                     #:accessor-name (or/c interned-symbol? #f))
-                    record-type?)]
+  [record-type
+   (->* (interned-symbol? keyset?)
+        (#:predicate-name (or/c interned-symbol? #f)
+         #:constructor-name (or/c interned-symbol? #f)
+         #:accessor-name (or/c interned-symbol? #f))
+        record-type?)]
   [record-type? predicate/c]
   [record-type-name (-> record-type? interned-symbol?)]
   [record-type-fields (-> record-type? keyset?)]
@@ -16,9 +17,9 @@
   [record-type-constructor-name (-> record-type? interned-symbol?)]
   [record-type-accessor-name (-> record-type? interned-symbol?)]))
 
-(require racket/syntax
-         rebellion/base/symbol
+(require rebellion/base/symbol
          rebellion/collection/keyset/low-dependency
+         rebellion/private/type-naming
          rebellion/type/tuple)
 
 ;@------------------------------------------------------------------------------
@@ -31,9 +32,10 @@
                      #:predicate-name [predicate-name* #f]
                      #:constructor-name [constructor-name* #f]
                      #:accessor-name [accessor-name* #f])
-  (define predicate-name (or predicate-name* (format-symbol "~a?" name)))
-  (define constructor-name (or constructor-name* name))
-  (define accessor-name (or accessor-name* (format-symbol "~a-ref" name)))
+  (define predicate-name (or predicate-name* (default-predicate-name name)))
+  (define constructor-name
+    (or constructor-name* (default-constructor-name name)))
+  (define accessor-name (or accessor-name* (default-accessor-name name)))
   (constructor:record-type name
                            fields
                            predicate-name

--- a/private/record-type.scrbl
+++ b/private/record-type.scrbl
@@ -52,23 +52,27 @@ obvious order to those pieces.
  #:grammar
  ([option
    #:omit-root-binding
-   (code:line #:constructor-name constructor-id)
+   (code:line #:descriptor-name descriptor-id)
    (code:line #:predicate-name predicate-id)
+   (code:line #:constructor-name constructor-id)
+   (code:line #:accessor-name accessor-id)
    (code:line #:pattern-name pattern-id)
-   (code:line #:property-maker prop-maker-expr)])
+   (code:line #:property-maker prop-maker-expr)
+   (code:line #:inspector inspector-expr)])
  
  #:contracts
  ([prop-maker-expr
    (-> uninitialized-record-descriptor?
-       (listof (cons/c struct-type-property? any/c)))])]{
+       (listof (cons/c struct-type-property? any/c)))]
+  [inspector-expr inspector?])]{
  Creates a new @tech{record type} named @racket[id] and binds the following
  identifiers:
 
  @itemlist[
- @item{@racket[constructor-id], which defaults to @racketidfont{
-    constructor:}@racket[id] --- a constructor function that accepts one
-   mandatory keyword argument for each @racket[field-id] and returns an instance
-   of the created type.}
+ @item{@racket[constructor-id], which defaults to
+   @racketidfont{constructor:}@racket[id] --- a @tech{record constructor} that
+   accepts one mandatory keyword argument for each @racket[field-id] and returns
+   an instance of the created type.}
 
  @item{@racket[predicate-id], which defaults to @racket[id]@racketidfont{?} ---
    a predicate function that returns @racket[#t] when given instances of the
@@ -78,6 +82,15 @@ obvious order to those pieces.
    --- an accessor function that returns the value for @racket[field-id] when
    given an instance of the created type.}
 
+ @item{@racket[accessor-id], which defaults @racketidfont{accessor:}@racket[id]
+   --- a @tech{record accessor} that accepts an instance of the created type and
+   an integer indicating which field to access, then returns the value of that
+   field.}
+
+ @item{@racket[descriptor-id], which defaults to
+   @racketidfont{descriptor:}@racket[id] --- the @tech{type descriptor} for the
+   created type.}
+
  @item{@racket[pattern-id], which defaults to @racketidfont{pattern:}@racket[id]
    --- a @tech/reference{match expander} that accepts one optional keyword and
    subpattern pair for each field and deconstructs instances of the created
@@ -85,10 +98,17 @@ obvious order to those pieces.
    for that field is given).}]
 
  Additionally, unless @racket[#:omit-root-binding] is specified, the original
- @racket[id] is bound to @racket[pattern-id] when used in match patterns and to
- @racket[constructor-id] when used as an expression. Use @racket[
- #:omit-root-binding] when you want control over what @racket[id] is bound to,
- such as when creating a smart constructor.
+ @racket[id] is bound to a @tech{record type binding} for the created type. The
+ binding behaves like @racket[pattern-id] when used in match patterns and like
+ @racket[constructor-id] when used as an expression. Use
+ @racket[#:omit-root-binding] when you want control over what @racket[id] is
+ bound to, such as when creating a smart constructor.
+ 
+ The @racket[prop-maker-expr] is used to add structure type properties to the
+ created type, and @racket[inspector-expr] is used to determine the
+ @tech/reference{inspector} that will control the created type. See
+ @racket[make-record-implementation] for more information about these
+ parameters.
 
  @(examples
    #:eval (make-evaluator) #:once

--- a/private/singleton-type-base.rkt
+++ b/private/singleton-type-base.rkt
@@ -12,11 +12,13 @@
   [singleton-type-predicate-name (-> singleton-type? interned-symbol?)]))
 
 (require rebellion/base/symbol
+         rebellion/private/type-naming
          rebellion/type/tuple)
 
 ;@------------------------------------------------------------------------------
 
 (define-tuple-type singleton-type (name predicate-name) #:omit-root-binding)
 
-(define (singleton-type name #:predicate-name [pred-name #f])
-  (constructor:singleton-type name pred-name))
+(define (singleton-type name #:predicate-name [predicate-name* #f])
+  (define predicate-name (or predicate-name* (default-predicate-name name)))
+  (constructor:singleton-type name predicate-name))

--- a/private/singleton-type.scrbl
+++ b/private/singleton-type.scrbl
@@ -48,22 +48,43 @@ of the constant causes a compile error rather than a silent bug at runtime.
 
 @defform[
  (define-singleton-type id singleton-option ...)
- #:grammar ([singleton-option
-             (code:line #:predicate-name predicate-id)
-             (code:line #:inspector inspector)
-             (code:line #:property-maker property-maker)])
- #:contracts ([inspector inspector?]
-              [property-maker
-               (-> uninitialized-singleton-descriptor?
-                   (listof (cons/c struct-type-property? any/c)))])]{
+ #:grammar
+ ([singleton-option
+   #:omit-root-binding
+   (code:line #:descriptor-name descriptor-id)
+   (code:line #:predicate-name predicate-id)
+   (code:line #:instance-name instance-id)
+   (code:line #:property-maker prop-maker-expr)
+   (code:line #:inspector inspector-expr)])
+ #:contracts
+ ([prop-maker-expr
+   (-> uninitialized-singleton-descriptor?
+       (listof (cons/c struct-type-property? any/c)))]
+  [inspector-expr inspector?])]{
  Creates a @tech{singleton type} and binds the following identifiers:
 
  @itemlist[
- @item{@racket[id] --- the unique instance of the created type.}
+ @item{@racket[instance-id], which defaults to
+   @racketidfont{instance:}@racket[id] --- the unique instance of the created
+   type.}
 
  @item{@racket[predicate-id], which defaults to @racket[id]@racketidfont{?} ---
    a predicate that returns @racket[#t] when given the singleton instance and
-   false for all other values.}]
+   false for all other values.}
+ 
+ @item{@racket[descriptor-id], which defaults to
+   @racketidfont{descriptor:}@racket[id] --- the @tech{type descriptor} for the
+   created type.}]
+
+  Additionally, unless @racket[#:omit-root-binding] is specified, the original
+ @racket[id] is bound to a @tech{singleton type binding} for the created type.
+ The binding behaves like @racket[instance-id] when used as an expression.
+ 
+ The @racket[prop-maker-expr] is used to add structure type properties to the
+ created type, and @racket[inspector-expr] is used to determine the
+ @tech/reference{inspector} that will control the created type. See
+ @racket[make-singleton-implementation] for more information about these
+ parameters.
 
  @(examples
    #:eval (make-evaluator) #:once

--- a/private/tuple-type-base.rkt
+++ b/private/tuple-type-base.rkt
@@ -22,8 +22,8 @@
 (require racket/list
          racket/math
          racket/sequence
-         racket/syntax
-         rebellion/base/symbol)
+         rebellion/base/symbol
+         rebellion/private/type-naming)
 
 ;@------------------------------------------------------------------------------
 
@@ -40,27 +40,22 @@
          #:accessor-name [accessor-name* #f])
   (define field-vector
     (vector->immutable-vector (for/vector ([field fields]) field)))
-  (check-field-names-unique field-vector)
-  (define predicate-name
-    (or predicate-name* (default-tuple-predicate-name name)))
-  (define constructor-name (or constructor-name* name))
-  (define accessor-name (or accessor-name* (default-tuple-accessor-name name)))
+  (check-field-names-unique field-vector name)
+  (define predicate-name (or predicate-name* (default-predicate-name name)))
+  (define constructor-name
+    (or constructor-name* (default-constructor-name name)))
+  (define accessor-name (or accessor-name* (default-accessor-name name)))
   (constructor:tuple-type
    name field-vector predicate-name constructor-name accessor-name))
 
 (define (tuple-type-size type)
   (vector-length (tuple-type-fields type)))
 
-(define (check-field-names-unique names)
+(define (check-field-names-unique names type-name)
   (define duplicate (check-duplicates (vector->list names)))
   (when duplicate
     (raise-arguments-error
      'tuple-type
      "duplicate field names are not allowed in tuple types"
-     "duplicate name" duplicate)))
-
-(define (default-tuple-predicate-name type-name)
-  (format-symbol "~a?" type-name))
-
-(define (default-tuple-accessor-name type-name)
-  (format-symbol "~a-ref" type-name))
+     "duplicate name" duplicate
+     "tuple type" type-name)))

--- a/private/tuple-type-descriptor.rkt
+++ b/private/tuple-type-descriptor.rkt
@@ -250,7 +250,7 @@
     (check-equal? (~a p) "#<point: 42 1000>")
     (check-equal? (~s p) "#<point: 42 1000>")
     (check-equal? (~v point-descriptor) "#<initialized-tuple-descriptor:point>")
-    (check-equal? (~v point) "#<procedure:point>")
+    (check-equal? (~v point) "#<procedure:constructor:point>")
     (check-equal? (~v point?) "#<procedure:point?>")
     (check-equal? (~v point-x) "#<procedure:point-x>")
     (check-equal? (~v point-y) "#<procedure:point-y>")))

--- a/private/tuple-type.scrbl
+++ b/private/tuple-type.scrbl
@@ -64,41 +64,60 @@ represent a single logical thing, and there is an obvious order to those pieces.
  #:grammar
  ([option
    #:omit-root-binding
-   (code:line #:constructor-name constructor-id)
+   (code:line #:descriptor-name descriptor-id)
    (code:line #:predicate-name predicate-id)
+   (code:line #:constructor-name constructor-id)
+   (code:line #:accessor-name accessor-id)
    (code:line #:pattern-name pattern-id)
-   (code:line #:property-maker prop-maker-expr)])
+   (code:line #:property-maker prop-maker-expr)
+   (code:line #:inspector inspector-expr)])
 
  #:contracts
  ([prop-maker-expr
    (-> uninitialized-tuple-descriptor?
-       (listof (cons/c struct-type-property? any/c)))])]{
+       (listof (cons/c struct-type-property? any/c)))]
+  [inspector-expr inspector?])]{
  Creates a new @tech{tuple type} named @racket[id] and binds the following
  identifiers:
 
  @itemlist[
- @item{@racket[constructor-id], which defaults to @racketidfont{
-    constructor:}@racket[id] --- a constructor function that accepts one
-   positional argument for each @racket[field-id] and returns an instance of the
-   created type.}
+ @item{@racket[constructor-id], which defaults to
+   @racketidfont{constructor:}@racket[id] --- a @tech{tuple constructor} that
+   accepts one positional argument for each @racket[field-id] and returns an
+   instance of the created type.}
 
  @item{@racket[predicate-id], which defaults to @racket[id]@racketidfont{?} ---
    a predicate function that returns @racket[#t] when given instances of the
    created type and returns @racket[#f] otherwise.}
 
  @item{@racket[id]@racketidfont{-}@racket[field-id] for each @racket[field-id]
-   --- an accessor function that returns the value for @racket[field-id] when
-   given an instance of the created type.}
+   --- a field accessor function that returns the value for @racket[field-id]
+   when given an instance of the created type.}
+
+ @item{@racket[accessor-id], which defaults @racketidfont{accessor:}@racket[id]
+   --- a @tech{tuple accessor} that accepts an instance of the created type and
+   an integer indicating which field to access, then returns the value of that
+   field.}
+
+ @item{@racket[descriptor-id], which defaults to
+   @racketidfont{descriptor:}@racket[id] --- the @tech{type descriptor} for the
+   created type.}
 
  @item{@racket[pattern-id], which defaults to @racketidfont{pattern:}@racket[id]
    --- a @tech/reference{match expander} that deconstructs instances of the
    created type and matches each field against a subpattern}]
 
  Additionally, unless @racket[#:omit-root-binding] is specified, the original
- @racket[id] is bound to @racket[pattern-id] when used in match patterns and to
+ @racket[id] is bound to a @tech{tuple type binding} for the created type. The
+ binding behaves like @racket[pattern-id] when used in match patterns and like
  @racket[constructor-id] when used as an expression. Use @racket[
  #:omit-root-binding] when you want control over what @racket[id] is bound to,
  such as when creating a smart constructor.
+
+ The @racket[prop-maker-expr] is used to add structure type properties to the
+ created type, and @racket[inspector-expr] is used to determine the
+ @tech/reference{inspector} that will control the created type. See
+ @racket[make-tuple-implementation] for more information about these parameters.
  
  @(examples
    #:eval (make-evaluator) #:once
@@ -126,10 +145,11 @@ represent a single logical thing, and there is an obvious order to those pieces.
  @racket[constructor-name], and @racket[accessor-name] arguments control the
  result of @racket[object-name] on the functions implementing the type. If not
  provided, @racket[predicate-name] defaults to @racket[name]@racketidfont{?},
- @racket[constructor-name] defaults to @racket[name], and @racket[accessor-name]
- defaults to @racket[name]@racketidfont{-ref}. Two tuple types constructed with
- the same arguments are @racket[equal?]. To make an implementation of a tuple
- type, see @racket[make-tuple-implementation].}
+ @racket[constructor-name] defaults to @racketidfont{constructor:}@racket[name],
+ and @racket[accessor-name] defaults to @racketidfont{accessor:}@racket[name].
+ Two tuple types constructed with the same arguments are @racket[equal?]. To
+ make an implementation of a tuple type, see
+ @racket[make-tuple-implementation].}
 
 @deftogether[[
  @defproc[(tuple-type-name [type tuple-type?]) interned-symbol?]

--- a/private/type-naming.rkt
+++ b/private/type-naming.rkt
@@ -1,0 +1,63 @@
+#lang racket/base
+
+(require racket/contract/base)
+
+(provide
+ (contract-out
+  [default-descriptor-identifier (-> identifier? identifier?)]
+  [default-predicate-name (-> interned-symbol? interned-symbol?)]
+  [default-predicate-identifier (-> identifier? identifier?)]
+  [default-constructor-name (-> interned-symbol? interned-symbol?)]
+  [default-constructor-identifier (-> identifier? identifier?)]
+  [default-accessor-name (-> interned-symbol? interned-symbol?)]
+  [default-accessor-identifier (-> identifier? identifier?)]
+  [default-discriminator-name (-> interned-symbol? interned-symbol?)]
+  [default-discriminator-identifier (-> identifier? identifier?)]
+  [default-selector-name (-> interned-symbol? interned-symbol?)]
+  [default-selector-identifier (-> identifier? identifier?)]
+  [default-opaque-constructor-name (-> interned-symbol? interned-symbol?)]
+  [default-opaque-constructor-identifier (-> identifier? identifier?)]
+  [default-pattern-identifier (-> identifier? identifier?)]
+  [default-setter-identifier (-> identifier? identifier?)]
+  [default-field-accessor-identifier (-> identifier? identifier? identifier?)]
+  [default-unwrapping-accessor-name (-> interned-symbol? interned-symbol?)]
+  [default-unwrapping-accessor-identifier (-> identifier? identifier?)]
+  [default-instance-identifier (-> identifier? identifier?)]))
+
+(require racket/syntax
+         rebellion/base/symbol)
+
+;@------------------------------------------------------------------------------
+
+(define (format-one-id template id) (format-id id template id #:subs? #true))
+
+(define (default-descriptor-identifier id) (format-one-id "descriptor:~a" id))
+(define (default-predicate-name name) (format-symbol "~a?" name))
+(define (default-predicate-identifier id) (format-one-id "~a?" id))
+(define (default-constructor-name name) (format-symbol "constructor:~a" name))
+(define (default-constructor-identifier id) (format-one-id "constructor:~a" id))
+(define (default-accessor-name name) (format-symbol "accessor:~a" name))
+(define (default-accessor-identifier id) (format-one-id "accessor:~a" id))
+
+(define (default-discriminator-name name)
+  (format-symbol "discriminator:~a" name))
+
+(define (default-discriminator-identifier id)
+  (format-one-id "discriminator:~a" id))
+
+(define (default-selector-name name) (format-symbol "selector:~a" name))
+(define (default-selector-identifier id) (format-one-id "selector:~a" id))
+(define (default-opaque-constructor-name name) (format-symbol "make-~a" name))
+(define (default-opaque-constructor-identifier id) (format-one-id "make-~a" id))
+(define (default-pattern-identifier id) (format-one-id "pattern:~a" id))
+(define (default-setter-identifier id) (format-one-id "~a-set" id))
+
+(define (default-field-accessor-identifier type-id field-id)
+  (format-id field-id "~a-~a" type-id field-id #:subs? #true))
+
+(define (default-unwrapping-accessor-name name) (format-symbol "~a-value" name))
+
+(define (default-unwrapping-accessor-identifier id)
+  (format-one-id "~a-value" id))
+
+(define (default-instance-identifier id) (format-one-id "instance:~a" id))

--- a/private/type.scrbl
+++ b/private/type.scrbl
@@ -153,8 +153,8 @@ build on top of the Rebellion type libraries. If you are interested in such a
 project please reach out to the Rebellion project owners, we'd love to hear
 more!
 
-@include-section[(lib "rebellion/private/record-type.scrbl")]
 @include-section[(lib "rebellion/private/tuple-type.scrbl")]
+@include-section[(lib "rebellion/private/record-type.scrbl")]
 @include-section[(lib "rebellion/private/enum-type.scrbl")]
 @include-section[(lib "rebellion/private/singleton-type.scrbl")]
 @include-section[(lib "rebellion/private/wrapper-type.scrbl")]

--- a/private/wrapper-type-base.rkt
+++ b/private/wrapper-type-base.rkt
@@ -16,8 +16,8 @@
   [wrapper-type-predicate-name (-> wrapper-type? interned-symbol?)]
   [wrapper-type-accessor-name (-> wrapper-type? interned-symbol?)]))
 
-(require racket/syntax
-         rebellion/base/symbol
+(require rebellion/base/symbol
+         rebellion/private/type-naming
          rebellion/type/record)
 
 ;@------------------------------------------------------------------------------
@@ -33,6 +33,6 @@
          #:accessor-name [accessor-name #f])
   (constructor:wrapper-type
    #:name name
-   #:predicate-name (or predicate-name (format-symbol "~a?" name))
-   #:constructor-name (or constructor-name name)
-   #:accessor-name (or accessor-name (format-symbol "~a-value" name))))
+   #:predicate-name (or predicate-name (default-predicate-name name))
+   #:constructor-name (or constructor-name (default-constructor-name name))
+   #:accessor-name (or accessor-name (default-unwrapping-accessor-name name))))

--- a/private/wrapper-type.scrbl
+++ b/private/wrapper-type.scrbl
@@ -59,12 +59,14 @@ distinguished.
    (code:line #:constructor-name constructor-id)
    (code:line #:accessor-name accessor-id)
    (code:line #:pattern-name pattern-id)
-   (code:line #:property-maker prop-maker-expr)])
+   (code:line #:property-maker prop-maker-expr)
+   (code:line #:inspector inspector-expr)])
 
  #:contracts
  ([prop-maker-expr
    (-> uninitialized-wrapper-descriptor?
-       (listof (cons/c struct-type-property? any/c)))])]{
+       (listof (cons/c struct-type-property? any/c)))]
+  [inspector-expr inspector?])]{
  Creates a new @tech{wrapper type} named @racket[id] and binds the following
  identifiers:
 
@@ -73,23 +75,34 @@ distinguished.
    a predicate function that returns @racket[#t] when given instances of the
    created type and returns @racket[#f] otherwise.}
   
- @item{@racket[constructor-id], which defaults to @racketidfont{
-    constructor:}@racket[id] --- a constructor function that wraps a value and
-   returns an instance of the created type.}
+ @item{@racket[constructor-id], which defaults to
+   @racketidfont{constructor:}@racket[id] --- a @tech{wrapper constructor} that
+   wraps a value and returns an instance of the created type.}
 
  @item{@racket[accessor-id], which defaults to @racket[id]@racketidfont{-value}
-   --- an accessor function that unwraps instances of the created type and
+   --- a @tech{wrapper accessor} that unwraps instances of the created type and
    returns their underlying value.}
+
+ @item{@racket[descriptor-id], which defaults to
+   @racketidfont{descriptor:}@racket[id] --- the @tech{type descriptor} for the
+   created type.}
 
  @item{@racket[pattern-id], which defaults to @racketidfont{pattern:}@racket[id]
    --- a @tech/reference{match expander} that unwraps instances of the created
    type and matches their contents against a subpattern.}]
 
  Additionally, unless @racket[#:omit-root-binding] is specified, the original
- @racket[id] is bound to @racket[pattern-id] when used in match patterns and to
- @racket[constructor-id] when used as an expression. Use @racket[
- #:omit-root-binding] when you want control over what @racket[id] is bound to,
- such as when creating a smart constructor.
+ @racket[id] is bound to a @tech{wrapper type binding} for the created type. The
+ binding behaves like @racket[pattern-id] when used in match patterns and like
+ @racket[constructor-id] when used as an expression. Use
+ @racket[#:omit-root-binding] when you want control over what @racket[id] is
+ bound to, such as when creating a smart constructor.
+ 
+ The @racket[prop-maker-expr] is used to add structure type properties to the
+ created type, and @racket[inspector-expr] is used to determine the
+ @tech/reference{inspector} that will control the created type. See
+ @racket[make-wrapper-implementation] for more information about these
+ parameters.
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -116,10 +129,10 @@ distinguished.
  @racket[accessor-name] arguments control the result of @racket[object-name] on
  the functions implementing the type. If not provided, @racket[predicate-name]
  defaults to @racket[name]@racketidfont{?}, @racket[constructor-name] defaults
- to @racket[name], and @racket[accessor-name] defaults to
- @racket[name]@racketidfont{-value}. Two wrapper types constructed with the same
- arguments are @racket[equal?]. To make an implementation of a wrapper type, see
- @racket[make-wrapper-implementation].}
+ to @racketidfont{constructor:}@racket[name], and @racket[accessor-name]
+ defaults to @racket[name]@racketidfont{-value}. Two wrapper types constructed
+ with the same arguments are @racket[equal?]. To make an implementation of a
+ wrapper type, see @racket[make-wrapper-implementation].}
 
 @deftogether[[
  @defproc[(wrapper-type-name [type wrapper-type?]) interned-symbol?]


### PR DESCRIPTION
Technically a breaking change, but only for users who actually change the default names of things created by the type definition macros (which is a very rare use case).