### PR TITLE
Use #true and #false instead of #t and #f

### DIFF
--- a/private/association-list.rkt
+++ b/private/association-list.rkt
@@ -12,12 +12,12 @@
   [association-list-unique-keys (-> association-list? set?)]
   [association-list-values (-> association-list? immutable-vector?)]
   [association-list-entries
-   (-> association-list? (vectorof entry? #:immutable #t #:flat? #t))]
+   (-> association-list? (vectorof entry? #:immutable #true #:flat? #true))]
   [association-list->hash
    (-> association-list?
        (hash/c any/c nonempty-immutable-vector?
-               #:immutable #t
-               #:flat? #t))]
+               #:immutable #true
+               #:flat? #true))]
   [association-list-contains-key? (-> association-list? any/c boolean?)]
   [association-list-contains-value? (-> association-list? any/c boolean?)]
   [association-list-contains-entry? (-> association-list? entry? boolean?)]

--- a/private/association-list.scrbl
+++ b/private/association-list.scrbl
@@ -113,7 +113,7 @@ key-value pairs.
    (association-list-values (association-list 'a 1 'b 2 'a 3 'b 4)))}
 
 @defproc[(association-list-entries [assoc association-list?])
-         (vectorof entry? #:immutable #t)]{
+         (vectorof entry? #:immutable #true)]{
  Returns all key-value mappings in @racket[assoc], as an immutable vector of
  @tech{entries}. The same ordering guarantees as @racket[
  association-list-values] apply to the returned entries.
@@ -124,8 +124,8 @@ key-value pairs.
 
 @defproc[(association-list-contains-key? [assoc association-list?] [k any/c])
          boolean?]{
- Returns @racket[#t] if @racket[assoc] contains any mappings for the key
- @racket[k], returns @racket[#f] otherwise.
+ Returns @racket[#true] if @racket[assoc] contains any mappings for the key
+ @racket[k], returns @racket[#false] otherwise.
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -135,8 +135,8 @@ key-value pairs.
 
 @defproc[(association-list-contains-value? [assoc association-list?] [v any/c])
          boolean?]{
- Returns @racket[#t] if @racket[assoc] contains any mappings with the value
- @racket[v], returns @racket[#f] otherwise.
+ Returns @racket[#true] if @racket[assoc] contains any mappings with the value
+ @racket[v], returns @racket[#false] otherwise.
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -146,8 +146,8 @@ key-value pairs.
 
 @defproc[(association-list-contains-entry? [assoc association-list?] [e entry?])
          boolean?]{
- Returns @racket[#t] if @racket[assoc] contains a mapping equal to @racket[e],
- returns @racket[#f] otherwise.
+ Returns @racket[#true] if @racket[assoc] contains a mapping equal to
+ @racket[e], returns @racket[#false] otherwise.
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -158,7 +158,7 @@ key-value pairs.
 
 @defproc[(association-list->hash [assoc association-list?])
          (hash/c any/c nonempty-immutable-vector?
-                 #:immutable #t)]{
+                 #:immutable #true)]{
  Converts @racket[assoc] into a hash table mapping keys to immutable vectors of
  their values.
 

--- a/private/atomic-boolean.rkt
+++ b/private/atomic-boolean.rkt
@@ -44,51 +44,51 @@
   (test-case (name-string atomic-boolean-compare-and-exchange!)
 
     (test-case "stay false"
-      (define bool (make-atomic-boolean #f))
-      (check-false (atomic-boolean-compare-and-exchange! bool #t #f))
+      (define bool (make-atomic-boolean #false))
+      (check-false (atomic-boolean-compare-and-exchange! bool #true #false))
       (check-false (atomic-boolean-get bool))
-      (check-false (atomic-boolean-compare-and-exchange! bool #f #f))
+      (check-false (atomic-boolean-compare-and-exchange! bool #false #false))
       (check-false (atomic-boolean-get bool)))
 
     (test-case "stay true"
-      (define bool (make-atomic-boolean #t))
-      (check-true (atomic-boolean-compare-and-exchange! bool #f #t))
+      (define bool (make-atomic-boolean #true))
+      (check-true (atomic-boolean-compare-and-exchange! bool #false #true))
       (check-true (atomic-boolean-get bool))
-      (check-true (atomic-boolean-compare-and-exchange! bool #t #t))
+      (check-true (atomic-boolean-compare-and-exchange! bool #true #true))
       (check-true (atomic-boolean-get bool)))
 
     (test-case "set false to true"
-      (define bool (make-atomic-boolean #f))
-      (check-false (atomic-boolean-compare-and-exchange! bool #t #t))
+      (define bool (make-atomic-boolean #false))
+      (check-false (atomic-boolean-compare-and-exchange! bool #true #true))
       (check-false (atomic-boolean-get bool))
-      (check-false (atomic-boolean-compare-and-exchange! bool #f #t))
+      (check-false (atomic-boolean-compare-and-exchange! bool #false #true))
       (check-true (atomic-boolean-get bool)))
 
     (test-case "set true to false"
-      (define bool (make-atomic-boolean #t))
-      (check-true (atomic-boolean-compare-and-exchange! bool #f #f))
+      (define bool (make-atomic-boolean #true))
+      (check-true (atomic-boolean-compare-and-exchange! bool #false #false))
       (check-true (atomic-boolean-get bool))
-      (check-true (atomic-boolean-compare-and-exchange! bool #t #f))
+      (check-true (atomic-boolean-compare-and-exchange! bool #true #false))
       (check-false (atomic-boolean-get bool))))
 
   (test-case (name-string atomic-boolean-get-then-set!)
 
     (test-case "stay false"
-      (define bool (make-atomic-boolean #f))
-      (check-false (atomic-boolean-get-then-set! bool #f))
+      (define bool (make-atomic-boolean #false))
+      (check-false (atomic-boolean-get-then-set! bool #false))
       (check-false (atomic-boolean-get bool)))
 
     (test-case "stay true"
-      (define bool (make-atomic-boolean #t))
-      (check-true (atomic-boolean-get-then-set! bool #t))
+      (define bool (make-atomic-boolean #true))
+      (check-true (atomic-boolean-get-then-set! bool #true))
       (check-true (atomic-boolean-get bool)))
 
     (test-case "set false to true"
-      (define bool (make-atomic-boolean #f))
-      (check-false (atomic-boolean-get-then-set! bool #t))
+      (define bool (make-atomic-boolean #false))
+      (check-false (atomic-boolean-get-then-set! bool #true))
       (check-true (atomic-boolean-get bool)))
 
     (test-case "set true to false"
-      (define bool (make-atomic-boolean #t))
-      (check-true (atomic-boolean-get-then-set! bool #f))
+      (define bool (make-atomic-boolean #true))
+      (check-true (atomic-boolean-get-then-set! bool #false))
       (check-false (atomic-boolean-get bool)))))

--- a/private/atomic-fixnum.rkt
+++ b/private/atomic-fixnum.rkt
@@ -6,7 +6,7 @@
  (contract-out
   [atomic-fixnum? predicate/c]
   [make-atomic-fixnum
-   (->* (fixnum?) (#:name (or/c interned-symbol? #f)) atomic-fixnum?)]
+   (->* (fixnum?) (#:name (or/c interned-symbol? #false)) atomic-fixnum?)]
   [atomic-fixnum-get (-> atomic-fixnum? fixnum?)]
   [rename set-atomic-fixnum-get! atomic-fixnum-set!
           (-> atomic-fixnum? fixnum? void?)]
@@ -54,7 +54,7 @@
 (define (atomic-fixnum-compare-and-set! num expected replacement)
   (unsafe-struct*-cas! num 0 expected replacement))
 
-(define (make-atomic-fixnum initial-value #:name [name #f])
+(define (make-atomic-fixnum initial-value #:name [name #false])
   (constructor:atomic-fixnum initial-value name))
 
 (define (atomic-fixnum-compare-and-add! num expected amount)

--- a/private/atomic-fixnum.scrbl
+++ b/private/atomic-fixnum.scrbl
@@ -56,8 +56,9 @@ operation again. This is a form of Optimistic Concurrency Control (OCC).
 @defproc[(atomic-fixnum? [v any/c]) boolean?]{
  A predicate for @tech{atomic fixnums}.}
 
-@defproc[(make-atomic-fixnum [initial-value fixnum?]
-                             [#:name name (or/c interned-symbol? #f) #f])
+@defproc[(make-atomic-fixnum
+          [initial-value fixnum?]
+          [#:name name (or/c interned-symbol? #false) #false])
          atomic-fixnum?]{
  Constructs a new @tech{atomic fixnum} named @racket[name] and set to @racket[
  initial-value]. Providing a @racket[name] is recommended for debugging and

--- a/private/bit.rkt
+++ b/private/bit.rkt
@@ -25,5 +25,5 @@
     (check-false (bit->boolean 0))
     (check-true (bit->boolean 1)))
   (test-case (name-string boolean->bit)
-    (check-equal? (boolean->bit #f) 0)
-    (check-equal? (boolean->bit #t) 1)))
+    (check-equal? (boolean->bit #false) 0)
+    (check-equal? (boolean->bit #true) 1)))

--- a/private/bit.scrbl
+++ b/private/bit.scrbl
@@ -33,5 +33,5 @@ A @deftech{bit} is either zero or one. Eight bits form a @tech{byte}, and a
 
  @(examples
    #:eval (make-evaluator) #:once
-   (boolean->bit #t)
-   (boolean->bit #f))}
+   (boolean->bit #true)
+   (boolean->bit #false))}

--- a/private/bitstring.rkt
+++ b/private/bitstring.rkt
@@ -53,7 +53,7 @@
        (for/list
            ([byte (in-bytes bytes)]
             [n (in-naturals)]
-            #:when #t
+            #:when #true
             [bit (in-range
                   (if (equal? n (sub1 num-bytes))
                       (- 8 padding)
@@ -85,7 +85,11 @@
              [current-index 0]
              #:result (void))
             ([b (in-sequences (in-list bits) (in-list padding-bits))]
-             [eighth-bit? (in-cycle (in-list (list #f #f #f #f #f #f #f #t)))])
+             [eighth-bit?
+              (in-cycle
+               (in-list
+                (list
+                 #false #false #false #false #false #false #false #true)))])
     (guarded-block
       (define next-byte (+ b (* current-byte 2)))
       (guard eighth-bit? else (values next-byte current-index))

--- a/private/byte.rkt
+++ b/private/byte.rkt
@@ -139,7 +139,7 @@
             (byte 1 1 1 1 1 1 0 1)
             (byte 1 1 1 1 1 1 1 0)))
     (for ([x (in-range 256)]
-          #:when #t
+          #:when #true
           [pattern (in-list test-patterns)]
           [i (in-range 8)])
       (check-equal? (byte-ref (byte-and x pattern) i) 0))
@@ -162,7 +162,7 @@
             (byte 0 0 0 0 0 0 1 0)
             (byte 0 0 0 0 0 0 0 1)))
     (for ([x (in-range 256)]
-          #:when #t
+          #:when #true
           [pattern (in-list test-patterns)]
           [i (in-range 8)])
         (check-equal? (byte-ref (byte-or x pattern) i) 1)))
@@ -214,7 +214,7 @@
             (byte 1 1 1 1 1 1 0 1)
             (byte 1 1 1 1 1 1 1 0)))
     (for ([x (in-range 256)]
-          #:when #t
+          #:when #true
           [pattern (in-list test-patterns)]
           [i (in-range 8)])
       (check-equal? (byte-ref (byte-nand x pattern) i) 1))
@@ -237,7 +237,7 @@
             (byte 0 0 0 0 0 0 1 0)
             (byte 0 0 0 0 0 0 0 1)))
     (for ([x (in-range 256)]
-          #:when #t
+          #:when #true
           [pattern (in-list test-patterns)]
           [i (in-range 8)])
       (check-equal? (byte-ref (byte-nor x pattern) i) 0))
@@ -267,7 +267,7 @@
 (module+ test
   (test-case (name-string in-byte)
     (for ([x (in-range 256)]
-          #:when #t
+          #:when #true
           [b (in-byte x)]
           [i (in-range 8)])
       (check-equal? b (byte-ref x i))))

--- a/private/comparator.scrbl
+++ b/private/comparator.scrbl
@@ -70,7 +70,7 @@ with equality unless otherwise stated.
 
 @defproc[(comparator-map [comparator comparator?]
                          [f (-> any/c any/c)]
-                         [#:name name (or/c interned-symbol? #f) #f])
+                         [#:name name (or/c interned-symbol? #false) #false])
          comparator?]{
  Wraps @racket[comparator] as a @tech{comparator} that first calls @racket[f] on
  both of its inputs before comparing them. Beware that this often creates a
@@ -85,7 +85,7 @@ with equality unless otherwise stated.
             (circle #:color 'blue #:radius 8)))}
 
 @defproc[(make-comparator [function (-> any/c any/c comparison?)]
-                          [#:name name (or/c interned-symbol? #f) #f])
+                          [#:name name (or/c interned-symbol? #false) #false])
          comparator?]{
  Constructs a @tech{comparator} named @racket[name] that compares values by
  calling @racket[function]. Most users should use @racket[comparator-map] to
@@ -200,9 +200,9 @@ with equality unless otherwise stated.
 
 @defproc[(comparator-impersonate
           [comparator comparator?]
-          [#:operand-guard operand-guard (or/c (-> any/c any/c #f)) #f]
+          [#:operand-guard operand-guard (or/c (-> any/c any/c #false)) #false]
           [#:properties properties
-           (hash/c impersonator-property? any/c #:immutable #t)
+           (hash/c impersonator-property? any/c #:immutable #true)
            empty-hash]
           [#:comparison-marks marks immutable-hash? empty-hash]
           [#:chaperone? chaperone? boolean? (false? operand-guard)])
@@ -227,7 +227,7 @@ with equality unless otherwise stated.
     (define printing-real<=>
       (comparator-impersonate real<=>
                               #:operand-guard (λ (x) (printf "Got ~a\n" x) x)
-                              #:chaperone? #t)))
+                              #:chaperone? #true)))
 
    (compare printing-real<=> 4 8)
    (chaperone-of? printing-real<=> real<=>))}

--- a/private/converter.rkt
+++ b/private/converter.rkt
@@ -6,7 +6,8 @@
  (contract-out
   [converter? predicate/c]
   [make-converter
-   (->* ((-> any/c any/c) (-> any/c any/c)) (#:name (or/c interned-symbol? #f))
+   (->* ((-> any/c any/c) (-> any/c any/c))
+        (#:name (or/c interned-symbol? #false))
         converter?)]
   [convert-forward (-> converter? any/c any/c)]
   [convert-backward (-> converter? any/c any/c)]
@@ -18,7 +19,7 @@
   [symbol<->keyword (converter/c symbol? keyword?)]
   [converter-pipe (-> converter? ... converter?)]
   [converter-flip
-   (->* (converter?) (#:name (or/c interned-symbol? #f)) converter?)]))
+   (->* (converter?) (#:name (or/c interned-symbol? #false)) converter?)]))
 
 (require racket/bool
          racket/contract/combinator
@@ -49,7 +50,7 @@
   #:constructor-name constructor:converter)
 
 
-(define (make-converter forward-function backward-function #:name [name #f])
+(define (make-converter forward-function backward-function #:name [name #false])
   (constructor:converter
    #:forward-function (fix-arity forward-function)
    #:backward-function (fix-arity backward-function)
@@ -74,10 +75,10 @@
 
 (define (converter-impersonate
          converter
-         #:domain-input-guard [domain-input-guard #f]
-         #:domain-output-guard [domain-output-guard #f]
-         #:range-input-guard [range-input-guard #f]
-         #:range-output-guard [range-output-guard #f]
+         #:domain-input-guard [domain-input-guard #false]
+         #:domain-output-guard [domain-output-guard #false]
+         #:range-input-guard [range-input-guard #false]
+         #:range-output-guard [range-output-guard #false]
          #:properties [properties (hash)]
          #:forward-marks [forward-marks (hash)]
          #:backward-marks [backward-marks (hash)]
@@ -125,13 +126,14 @@
   (define (projection blame)
     (define domain-input-blame
       (blame-add-context blame "an input in the converter domain of"
-                         #:swap? #t))
+                         #:swap? #true))
     (define domain-output-blame
       (blame-add-context blame "an output in the converter domain of"))
     (define range-output-blame
       (blame-add-context blame "an output in the converter range of"))
     (define range-input-blame
-      (blame-add-context blame "an input in the converter range of" #:swap? #t))
+      (blame-add-context
+       blame "an input in the converter range of" #:swap? #true))
     (define late-neg-domain-input-guard (domain-projection domain-input-blame))
     (define late-neg-range-output-guard (range-projection range-output-blame))
     (define late-neg-range-input-guard (range-projection range-input-blame))

--- a/private/converter.scrbl
+++ b/private/converter.scrbl
@@ -53,7 +53,7 @@ a single time. Converters are typically named in the pattern
 @defproc[(make-converter
           [forward-function (-> any/c any/c)]
           [backward-function (-> any/c any/c)]
-          [#:name name (or/c interned-symbol? #f) #f])
+          [#:name name (or/c interned-symbol? #false) #false])
          converter?]{
  Constructs a @tech{converter} named @racket[name] that uses
  @racket[forward-function] and @racket[backward-function] to convert values.

--- a/private/custom-write.rkt
+++ b/private/custom-write.rkt
@@ -7,7 +7,7 @@
   [custom-write-mode/c flat-contract?]
   [custom-write-function/c chaperone-contract?]
   [make-named-object-custom-write
-   (->* (symbol?) (#:name-getter (-> any/c (or/c symbol? #f)))
+   (->* (symbol?) (#:name-getter (-> any/c (or/c symbol? #false)))
         custom-write-function/c)]))
 
 ;@------------------------------------------------------------------------------

--- a/private/custom-write.scrbl
+++ b/private/custom-write.scrbl
@@ -34,12 +34,13 @@ must satisfy the @racket[custom-write-function/c] contract.
 
 @defthing[custom-write-mode/c flat-contract?
           #:value (or/c boolean? 0 1)]{
- A @tech/reference{contract} describing the @racket[_mode] argument to functions matching
- @racket[custom-write-function/c]. See @racket[gen:custom-write] for details.}
+ A @tech/reference{contract} describing the @racket[_mode] argument to functions
+ matching @racket[custom-write-function/c]. See @racket[gen:custom-write] for
+ details.}
 
 @defproc[(make-named-object-custom-write
           [type-name symbol?]
-          [#:name-getter get-name (-> any/c (or/c symbol? #f)) object-name])
+          [#:name-getter get-name (-> any/c (or/c symbol? #false)) object-name])
          custom-write-function/c]{
  Constructs a @tech{custom write implementation} that prints values as opaque,
  unreadable, named objects, similar to the way functions are printed.
@@ -52,4 +53,4 @@ must satisfy the @racket[custom-write-function/c] contract.
 
    (person 'alyssa)
    (person 'jared)
-   (person #f))}
+   (person #false))}


### PR DESCRIPTION
The shorthands are hard to read and easy to confuse with each other. This pull request doesn't rewrite them everywhere because I only got around to doing it in a few files. This cleanup will probably be a gradual thing.