### PR TITLE
Add taking-duplicates

### DIFF
--- a/private/transducer-deduplicating.rkt
+++ b/private/transducer-deduplicating.rkt
@@ -7,9 +7,7 @@
   [deduplicating (->* () (#:key (-> any/c any/c)) transducer?)]
   [deduplicating-consecutive (->* () (#:key (-> any/c any/c)) transducer?)]))
 
-(require racket/contract/region
-         racket/set
-         rebellion/base/equivalence-relation
+(require racket/set
          rebellion/base/impossible-function
          rebellion/base/option
          rebellion/base/variant

--- a/private/transducer-taking-duplicates-test.rkt
+++ b/private/transducer-taking-duplicates-test.rkt
@@ -1,0 +1,68 @@
+#lang racket/base
+
+(module+ test
+  (require rackunit
+           rebellion/base/immutable-string
+           rebellion/collection/list
+           rebellion/private/static-name
+           rebellion/streaming/reducer
+           rebellion/streaming/transducer
+           rebellion/streaming/transducer/testing))
+
+;@------------------------------------------------------------------------------
+
+(module+ test
+  (test-case (name-string taking-duplicates)
+    (test-case "should compare entire values by default"
+      (define trans (taking-duplicates))
+      (define inputs "hello world")
+      (define expected "lol")
+      (check-equal? (transduce inputs trans #:into into-string) expected)
+      (define actual-events (transduce inputs (observing-transduction-events trans) #:into into-list))
+      (define expected-events
+        (list start-event
+              (consume-event #\h)
+              (consume-event #\e)
+              (consume-event #\l)
+              (consume-event #\l)
+              (emit-event #\l)
+              (consume-event #\o)
+              (consume-event #\space)
+              (consume-event #\w)
+              (consume-event #\o)
+              (emit-event #\o)
+              (consume-event #\r)
+              (consume-event #\l)
+              (emit-event #\l)
+              (consume-event #\d)
+              half-close-event
+              finish-event))
+      (check-equal? actual-events expected-events))
+
+    (test-case "should compare elements using given key function"
+      (define trans (taking-duplicates #:key immutable-string-foldcase))
+      (define inputs (list "foo" "FOO" "Bar" "bar" "Foo"))
+      (define expected (list "FOO" "bar" "Foo"))
+      (check-equal? (transduce inputs trans #:into into-list) expected)
+      (define actual-events (transduce inputs (observing-transduction-events trans) #:into into-list))
+      (define expected-events
+        (list start-event
+              (consume-event "foo")
+              (consume-event "FOO")
+              (emit-event "FOO")
+              (consume-event "Bar")
+              (consume-event "bar")
+              (emit-event "bar")
+              (consume-event "Foo")
+              (emit-event "Foo")
+              half-close-event
+              finish-event))
+      (check-equal? actual-events expected-events))
+
+    (test-case "should emit nothing when upstream sequence empty"
+      (define trans (taking-duplicates))
+      (check-equal? (transduce empty-list trans #:into into-list) empty-list)
+      (define actual-events
+        (transduce empty-list (observing-transduction-events trans) #:into into-list))
+      (define expected-events (list start-event half-close-event finish-event))
+      (check-equal? actual-events expected-events))))

--- a/private/transducer-taking-duplicates.rkt
+++ b/private/transducer-taking-duplicates.rkt
@@ -1,0 +1,38 @@
+#lang racket/base
+
+(require racket/contract/base)
+
+(provide
+ (contract-out
+  [taking-duplicates (->* () (#:key (-> any/c any/c)) transducer?)]))
+
+(require racket/set
+         rebellion/base/impossible-function
+         rebellion/base/variant
+         rebellion/private/static-name
+         rebellion/streaming/transducer/base)
+
+;@----------------------------------------------------------------------------------------------------
+
+(define/name (taking-duplicates #:key [key-function values])
+
+  (define (start) (variant #:consume (set)))
+
+  (define (consume state element)
+    (define key (key-function element))
+    (if (set-member? state key)
+        (variant #:emit (emission (variant #:consume state) element))
+        (variant #:consume (set-add state key))))
+
+  (define (emit state) state)
+
+  (define (half-close state) (variant #:finish #false))
+
+  (make-transducer
+   #:starter start
+   #:consumer consume
+   #:emitter emit
+   #:half-closer half-close
+   #:half-closed-emitter impossible
+   #:finisher void
+   #:name enclosing-function-name))

--- a/private/transducer.scrbl
+++ b/private/transducer.scrbl
@@ -263,6 +263,24 @@ early, before the input sequence is fully consumed.
               (taking-maxima #:key string-length)
               #:into into-list))}
 
+@defproc[(taking-duplicates [#:key key-function (-> any/c any/c) values]) transducer?]{
+ Constructs a @tech{transducer} that keeps only the duplicate elements of the transduced sequence.
+ The first time an element occurs, it is removed from the sequence. Subsequent occurrences of that
+ element are emitted downstream.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (transduce "hello world" (taking-duplicates) #:into into-string))
+
+ If @racket[key-function] is provided, then it is used to extract a key from each element and only
+ elements with duplicate keys are emitted downstream.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (transduce (list "red" "yellow" "blue" "purple" "green")
+              (taking-duplicates #:key string-length)
+              #:into into-list))}
+
 @defproc[(dropping [amount natural?]) transducer?]{
  Constructs a @tech{transducer} that removes the first @racket[amount] elements
  from the transduced sequence, then passes all remaining elements downstream.

--- a/streaming/transducer.rkt
+++ b/streaming/transducer.rkt
@@ -8,5 +8,6 @@ rebellion/private/transducer-deduplicating
 rebellion/private/transducer-enumerating
 rebellion/private/transducer-reducer
 rebellion/private/transducer-sorting
+rebellion/private/transducer-taking-duplicates
 rebellion/private/transducer-taking-maxima
 rebellion/private/transducer-windowing


### PR DESCRIPTION
This is mostly for constructing error messages in functions that want to reject duplicate arguments, similar to the use cases of the `check-duplicates` and `check-duplicate-identifier` functions.