### PR TITLE
Soft-deprecate reduce and reduce-all

### DIFF
--- a/private/reducer.scrbl
+++ b/private/reducer.scrbl
@@ -39,37 +39,27 @@
 @title{Reducers}
 @defmodule[rebellion/streaming/reducer]
 
-A @deftech{reducer} is an object that can combine a (possibly infinite)
-@tech/reference{sequence} of elements into a single result value. Reducers are
-state machines; performing a reduction involves @emph{starting} the reducer to
-get an initial state, then @emph{consuming} elements one at a time to transform
-the current state into a new, updated state. When no more elements are
-available, the reducer's @emph{finisher} is called to transform the final state
-into a result value. Optionally, a reducer may terminate the reduction early,
-before the sequence is fully consumed.
+A @deftech{reducer} is an object that can combine a (possibly infinite) @tech/reference{sequence} of
+elements into a single result value. Reducers form the final step of a @tech{stream pipeline} and
+specify how the output elements of the pipeline should be collected into a final result. To use a
+reducer, pass it as the @racket[#:into] argument to the @racket[transduce] function.
+
+@(examples
+  #:eval (make-evaluator) #:once
+  (transduce (in-range 0 10)
+             (filtering even?)
+             #:into into-list))
+
+Reducers are state machines; performing a reduction involves @emph{starting} the reducer to get an
+initial state, then @emph{consuming} elements one at a time to transform the current state into a new,
+updated state. When no more elements are available, the reducer's @emph{finisher} is called to
+transform the final state into a result value. Optionally, a reducer may terminate the reduction
+early, before the sequence is fully consumed. This process is known as the
+@deftech{reduction protocol}: see @racket[make-reducer] for a more concrete description of the
+protocol.
 
 @defproc[(reducer? [v any/c]) boolean?]{
  A predicate for @tech{reducers}.}
-
-@defproc[(reduce [red reducer?] [v any/c] ...) any/c]{
- Reduces @racket[v]s with @racket[red], in left-to-right order.
-
- @(examples
-   #:eval (make-evaluator) #:once
-   (reduce into-sum 1 2 3 4 5 6 7 8 9 10)
-   (reduce into-product 2 3 5 7 11 13 17 19 23)
-   (reduce into-count 'a 'b 'c 'd 'e))}
-
-@defproc[(reduce-all [red reducer?] [seq sequence?]) any/c]{
- Reduces @racket[seq] with @racket[red]. The sequence is iterated lazily, so if
- @racket[red] terminates the reduction early then the sequence will not be fully
- traversed.
-
- @(examples
-   #:eval (make-evaluator) #:once
-   (reduce-all into-sum (in-range 1 100))
-   (reduce-all into-product (in-range 1 20))
-   (reduce-all into-count (in-hash-values (hash 'a 1 'b 2 'c 3 'd 4))))}
 
 @defthing[into-sum (reducer/c number? number?)]{
  A @tech{reducer} that reduces a sequence of numbers into their sum with
@@ -77,9 +67,9 @@ before the sequence is fully consumed.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce into-sum 1 2 3)
-   (reduce into-sum)
-   (reduce-all into-sum (in-range 10000)))}
+   (transduce (list 1 2 3) #:into into-sum)
+   (transduce empty-list #:into into-sum)
+   (transduce (in-range 10000) #:into into-sum))}
 
 @defthing[into-product (reducer/c number? number?)]{
  A @tech{reducer} that reduces a sequence of numbers into their product with
@@ -87,9 +77,9 @@ before the sequence is fully consumed.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce into-product 2 3 4)
-   (reduce into-product)
-   (reduce-all into-product (in-range 1 20)))}
+   (transduce (list 2 3 4) #:into into-product)
+   (transduce empty-list #:into into-product)
+   (transduce (in-range 1 20) #:into into-product))}
 
 @defthing[into-count (reducer/c any/c number?)]{
  A @tech{reducer} that ignores the specific elements it reduces and returns only
@@ -97,8 +87,8 @@ before the sequence is fully consumed.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce into-count 'a 'b 'c)
-   (reduce-all into-count "hello world"))}
+   (transduce (list 'a 'b 'c) #:into into-count)
+   (transduce "hello world" #:into into-count))}
 
 @defthing[into-first (reducer/c any/c option?)]{
  A @tech{reducer} that returns an @tech{option} of the first element it reduces, or @racket[absent]
@@ -164,9 +154,9 @@ before the sequence is fully consumed.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce-all (into-nth 8) "hello world")
-   (reduce-all (into-nth 20) "hello world")
-   (reduce-all (into-nth 0) "hello world"))}
+   (transduce "hello world" #:into (into-nth 8))
+   (transduce "hello world" #:into (into-nth 20))
+   (transduce "hello world" #:into (into-nth 0)))}
 
 @defproc[(into-index-of [v any/c]) (reducer/c any/c (option/c natural?))]{
  Constructs a @tech{reducer} that searches the reduced sequence for @racket[v]
@@ -176,8 +166,8 @@ before the sequence is fully consumed.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce-all (into-index-of #\e) "battery")
-   (reduce-all (into-index-of #\o) "cat"))}
+   (transduce "battery" #:into (into-index-of #\e))
+   (transduce "cat" #:into (into-index-of #\e)))}
 
 @defproc[(into-index-where [pred predicate/c])
          (reducer/c any/c (option/c natural?))]{
@@ -188,8 +178,8 @@ before the sequence is fully consumed.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce-all (into-index-where char-whitespace?) "hello world")
-   (reduce-all (into-index-where char-numeric?) "goodbye world"))}
+   (transduce "hello world" #:into (into-index-where char-whitespace?))
+   (transduce "hello world" #:into (into-index-where char-numeric?)))}
 
 @defproc[(into-any-match? [pred predicate/c]) (reducer/c any/c boolean?)]{
  Constructs a @tech{reducer} that searches the reduced sequence for at least one
@@ -199,9 +189,9 @@ before the sequence is fully consumed.
  
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce-all (into-any-match? char-whitespace?) "hello world")
-   (reduce-all (into-any-match? char-numeric?) "hello world")
-   (reduce-all (into-any-match? char-whitespace?) ""))}
+   (transduce "hello world" #:into (into-any-match? char-whitespace?))
+   (transduce "hello" #:into (into-any-match? char-whitespace?))
+   (transduce "" #:into (into-any-match? char-whitespace?)))}
 
 @defproc[(into-all-match? [pred predicate/c]) (reducer/c any/c boolean?)]{
  Constructs a @tech{reducer} that returns true if every element in the reduced
@@ -210,9 +200,9 @@ before the sequence is fully consumed.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce-all (into-all-match? char-alphabetic?) "hello")
-   (reduce-all (into-all-match? char-alphabetic?) "hello world")
-   (reduce-all (into-all-match? char-alphabetic?) ""))}
+   (transduce "hello" #:into (into-all-match? char-alphabetic?))
+   (transduce "hello world" #:into (into-all-match? char-alphabetic?))
+   (transduce "" #:into (into-all-match? char-alphabetic?)))}
 
 @defproc[(into-none-match? [pred predicate/c]) (reducer/c any/c boolean?)]{
  Constructs a @tech{reducer} that returns true if no element in the reduced
@@ -221,9 +211,9 @@ before the sequence is fully consumed.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce-all (into-none-match? char-whitespace?) "hello")
-   (reduce-all (into-none-match? char-whitespace?) "hello world")
-   (reduce-all (into-none-match? char-whitespace?) ""))}
+   (transduce "hello" #:into (into-none-match? char-whitespace?))
+   (transduce "hello world" #:into (into-none-match? char-whitespace?))
+   (transduce "" #:into (into-none-match? char-whitespace?)))}
 
 @defproc[(into-for-each [handler (-> any/c void?)]) (reducer/c any/c void?)]{
  Constructs a @tech{reducer} that calls @racket[handler] on each element for its
@@ -232,7 +222,7 @@ before the sequence is fully consumed.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce-all (into-for-each displayln) (in-range 5)))}
+   (transduce (in-range 5) #:into (into-for-each displayln)))}
 
 @deftogether[[
  @defproc[(into-max [comparator comparator? real<=>]
@@ -343,8 +333,7 @@ before the sequence is fully consumed.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce into-string #\h #\e #\l #\l #\o)
-   (reduce-all into-string (list #\a #\b #\c)))}
+   (transduce (list #\h #\e #\l #\l #\o) #:into into-string))}
 
 @defthing[into-line (reducer/c char? immutable-string?)]{
  Like @racket[into-string], but stops the reduction as soon as a @racket[
@@ -352,10 +341,8 @@ before the sequence is fully consumed.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce-all into-line
-               "Haikus are easy
-But sometimes they don't make sense
-Refrigerator"))}
+   (transduce "Haikus are easy\nBut sometimes they don't make sense\nRefrigerator"
+              #:into into-line))}
 
 @defproc[(join-into-string
           [sep immutable-string?]
@@ -368,12 +355,15 @@ Refrigerator"))}
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce-all (join-into-string " + ")
-               (sequence-map number->immutable-string (in-range 1 10)))
-   (reduce-all (join-into-string ", " #:before-last ", and ")
-               (sequence-map number->immutable-string (in-range 1 10)))
-   (reduce-all (join-into-string ", " #:before-first "func(" #:after-last ")")
-               (sequence-map number->immutable-string (in-range 1 10))))}
+   (transduce (in-range 1 10)
+              (mapping number->immutable-string)
+              #:into (join-into-string " + "))
+   (transduce (in-range 1 10)
+              (mapping number->immutable-string)
+              #:into (join-into-string ", " #:before-last ", and "))
+   (transduce (in-range 1 10)
+              (mapping number->immutable-string)
+              #:into (join-into-string ", " #:before-first "func(" #:after-last ")")))}
 
 @section{Reducer Constructors}
 
@@ -393,7 +383,7 @@ reducers with increasing power and complexity:
   superset of fold reducers.}
 
  @item{@racket[make-reducer] constructs general @tech{reducers}, with the full
-  power of the reduction protocol and the ability to terminate the sequence
+  power of the @tech{reduction} protocol and the ability to terminate the sequence
   early.}]
 
 @defproc[(make-fold-reducer
@@ -411,7 +401,7 @@ reducers with increasing power and complexity:
    #:eval (make-evaluator) #:once
    (define into-reversed-list
      (make-fold-reducer (λ (lst v) (cons v lst)) (list)))
-   (reduce-all into-reversed-list (in-range 5 25)))}
+   (transduce (in-range 5 25) #:into into-reversed-list))}
 
 @defproc[(make-effectful-fold-reducer
           [consumer (-> any/c any/c any/c)]
@@ -431,7 +421,7 @@ reducers with increasing power and complexity:
    #:eval (make-evaluator) #:once
    (define into-list
      (make-effectful-fold-reducer (λ (lst v) (cons v lst)) list reverse))
-   (reduce-all into-list (in-range 5 25)))}
+   (transduce (in-range 5 25) #:into into-list))}
 
 @defproc[(make-reducer
           [#:starter starter
@@ -442,8 +432,8 @@ reducers with increasing power and complexity:
           [#:early-finisher early-finisher (-> any/c any/c)]
           [#:name name (or/c interned-symbol? #f) #f])
          reducer?]{
- Constructs a @tech{reducer} that reduces sequences by following the following
- steps, known as the @deftech{reduction protocol}:
+ Constructs a @tech{reducer} that reduces sequences by following the following steps, known as the
+ @tech{reduction protocol}:
 
  @itemlist[
  @item{Start the reduction by calling @racket[(starter)] to create the initial
@@ -488,8 +478,8 @@ reducers with increasing power and complexity:
         (vector->immutable-vector (vector-copy vec 0 i)))
       #:early-finisher vector->immutable-vector))
 
-   (reduce into-small-immutable-vector 1 2 3)
-   (reduce-all into-small-immutable-vector (in-naturals)))}
+   (transduce (list 1 2 3) #:into into-small-immutable-vector)
+   (transduce (in-naturals) #:into into-small-immutable-vector))}
 
 @deftogether[[
  @defproc[(reducer-starter [red reducer?])
@@ -515,13 +505,11 @@ reducers with increasing power and complexity:
    #:eval (make-evaluator) #:once
    (define into-total-letters
      (reducer-map into-sum #:domain string-length))
-   (reduce into-total-letters "the" "quick" "brown" "fox")
+   (transduce (list "the" "quick" "brown" "fox") #:into into-total-letters)
 
    (define stringly-typed-into-sum
-     (reducer-map into-sum
-                  #:domain string->number
-                  #:range number->string))
-   (reduce stringly-typed-into-sum "12" "5" "42" "17"))}
+     (reducer-map into-sum #:domain string->number #:range number->string))
+   (transduce (list "12" "5" "42" "17") #:into stringly-typed-into-sum))}
 
 @defproc[(reducer-filter [red reducer?] [pred predicate/c]) reducer?]{
  Wraps @racket[red] to only reduce sequence elements for which @racket[pred]
@@ -530,8 +518,7 @@ reducers with increasing power and complexity:
 
  @(examples
    #:eval (make-evaluator) #:once
-   (define numbers-into-sum (reducer-filter into-sum number?))
-   (reduce numbers-into-sum 1 'a 2 3 'b 'c 'd 4 'e 5))}
+   (transduce (list 1 'a 2 3 'b 'c 'd 4 'e 5) #:into (reducer-filter into-sum number?)))}
 
 @defproc[(reducer-limit [red reducer?] [amount natural?]) reducer?]{
  Wraps @racket[red] to only accept at most @racket[amount] elements before
@@ -539,7 +526,7 @@ reducers with increasing power and complexity:
 
  @(examples
    #:eval (make-evaluator) #:once
-   (reduce-all (reducer-limit into-string 5) "hello world"))}
+   (transduce "hello world" #:into (reducer-limit into-string 5)))}
 
 @section{Iteration and Comprehension with Reducers}
 
@@ -601,8 +588,8 @@ reducers with increasing power and complexity:
       (reducer/c string? string?)
       (make-fold-reducer string-append "" #:name 'into-string-append)))
 
-   (reduce into-string-append "Red" "Blue" "Green")
-   (eval:error (reduce into-string-append "Red" 42 "Green")))}
+   (transduce (list "Red" "Blue" "Green") #:into into-string-append)
+   (eval:error (transduce (list "Red" 42 "Green") #:into into-string-append)))}
 
 @section{Reducer Chaperones and Impersonators}
 
@@ -643,4 +630,29 @@ reducers with increasing power and complexity:
       (reducer-impersonate into-list
                            #:domain-guard print-domain
                            #:range-guard print-range)))
-   (reduce-all into-list/printing (in-range 5)))}
+   (transduce (in-range 5) #:into into-list/printing))}
+
+@section{Legacy Reduction APIs}
+
+@defproc[(reduce [red reducer?] [v any/c] ...) any/c]{
+ Reduces @racket[v]s with @racket[red], in left-to-right order. Use of this function is lightly
+ discouraged in favor of using @racket[transduce] with a list of values, as it's simpler and more
+ consistent if @racket[transduce] is the only entrypoint to the reducer and transducer APIs.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (reduce into-sum 1 2 3 4 5 6 7 8 9 10)
+   (reduce into-product 2 3 5 7 11 13 17 19 23)
+   (reduce into-count 'a 'b 'c 'd 'e))}
+
+@defproc[(reduce-all [red reducer?] [seq sequence?]) any/c]{
+ Reduces @racket[seq] with @racket[red]. The sequence is iterated lazily, so if @racket[red]
+ terminates the reduction early then the sequence will not be fully traversed. Use of this function is
+ lightly discouraged in favor of using @racket[transduce], as it's simpler and more consistent if
+ @racket[transduce] is the only entrypoint to the reducer and transducer APIs.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (reduce-all into-sum (in-range 1 100))
+   (reduce-all into-product (in-range 1 20))
+   (reduce-all into-count (in-hash-values (hash 'a 1 'b 2 'c 3 'd 4))))}


### PR DESCRIPTION
Having three different ways of using reducers is pretty weird, especially when two of them don't support transducers at all and take arguments in the opposite order of `transduce`. Since `transduce` is the main API for `rebellion/streaming`, we discourage the other two forms and rewrite the documentation examples in terms of `transduce`.