### PR TITLE
Add reducer-zip

### DIFF
--- a/binary/byte.rkt
+++ b/binary/byte.rkt
@@ -143,7 +143,7 @@
           [pattern (in-list test-patterns)]
           [i (in-range 8)])
       (check-equal? (byte-ref (byte-and x pattern) i) 0))
-    (for* ([x (in-range 256)] [y (in-range 256)])
+    (for* ([x (in-range 0 256 4)] [y (in-range 0 256 4)])
       (check-equal? (byte-and x y) (byte-and y x)))))
 
 (define (byte-or left right)
@@ -166,7 +166,7 @@
           [pattern (in-list test-patterns)]
           [i (in-range 8)])
         (check-equal? (byte-ref (byte-or x pattern) i) 1)))
-    (for* ([x (in-range 256)] [y (in-range 256)])
+    (for* ([x (in-range 0 256 4)] [y (in-range 0 256 4)])
       (check-equal? (byte-or x y) (byte-or y x))))
 
 (define (byte-not b)
@@ -218,7 +218,7 @@
           [pattern (in-list test-patterns)]
           [i (in-range 8)])
       (check-equal? (byte-ref (byte-nand x pattern) i) 1))
-    (for* ([x (in-range 256)] [y (in-range 256)])
+    (for* ([x (in-range 0 256 4)] [y (in-range 0 256 4)])
       (check-equal? (byte-nand x y) (byte-nand y x)))))
 
 (define (byte-nor left right)
@@ -241,7 +241,7 @@
           [pattern (in-list test-patterns)]
           [i (in-range 8)])
       (check-equal? (byte-ref (byte-nor x pattern) i) 0))
-    (for* ([x (in-range 256)] [y (in-range 256)])
+    (for* ([x (in-range 0 256 4)] [y (in-range 0 256 4)])
       (check-equal? (byte-nor x y) (byte-nor y x)))))
 
 (define (byte-xnor left right)

--- a/streaming/reducer.rkt
+++ b/streaming/reducer.rkt
@@ -6,7 +6,6 @@
  for/reducer
  for*/reducer
  (contract-out
-  [reducer/c (-> contract? contract? contract?)]
   [make-fold-reducer
    (->* ((-> any/c any/c any/c) any/c)
         (#:name (or/c interned-symbol? #f))
@@ -48,13 +47,6 @@
          #:before-last immutable-string?
          #:after-last immutable-string?)
         (reducer/c immutable-string? immutable-string?))]
-  [reducer-impersonate
-   (->* (reducer?)
-        (#:domain-guard (or/c (-> any/c any/c) #f)
-         #:range-guard (or/c (-> any/c any/c) #f)
-         #:properties impersonator-property-hash/c
-         #:chaperone? boolean?)
-        reducer?)]
   [reducer-map
    (->* (reducer?)
         (#:domain (-> any/c any/c) #:range (-> any/c any/c))
@@ -83,7 +75,6 @@
          rebellion/private/impersonation
          rebellion/private/static-name
          rebellion/streaming/reducer/private/base
-         (submod rebellion/streaming/reducer/private/base for-contracts)
          rebellion/streaming/reducer/private/zip
          rebellion/type/record
          rebellion/type/object
@@ -170,146 +161,6 @@
                   210)
     (check-equal? (reduce-all into-count (in-string "abcde")) 5)))
 
-;@------------------------------------------------------------------------------
-;; Contracts
-
-(define ((reducer-consumer-guard domain-guard) state element)
-  (values state (domain-guard element)))
-
-(define (reducer-impersonate
-         reducer
-         #:domain-guard [domain-guard #false]
-         #:range-guard [range-guard #false]
-         #:properties [properties (hash)]
-         #:chaperone?
-         [chaperone? (and (false? domain-guard) (false? range-guard))])
-  (define consumer (reducer-consumer reducer))
-  (define finisher (reducer-finisher reducer))
-  (define early-finisher (reducer-early-finisher reducer))
-  (define domain-chaperone? (or chaperone? (false? domain-guard)))
-  (define range-chaperone? (or chaperone? (false? range-guard)))
-
-  (define impersonated-consumer
-    (function-impersonate
-     consumer
-     #:arguments-guard (and domain-guard (reducer-consumer-guard domain-guard))
-     #:chaperone? domain-chaperone?))
-
-  (define impersonated-finisher
-    (function-impersonate finisher
-                          #:results-guard range-guard
-                          #:chaperone? range-chaperone?))
-  
-  (define impersonated-early-finisher
-    (function-impersonate early-finisher
-                          #:results-guard range-guard
-                          #:chaperone? range-chaperone?))
-  
-  (define impersonated-without-props
-    (make-reducer #:starter (reducer-starter reducer)
-                  #:consumer impersonated-consumer
-                  #:finisher impersonated-finisher
-                  #:early-finisher impersonated-early-finisher
-                  #:name (object-name reducer)))
-  
-  (object-impersonate impersonated-without-props descriptor:reducer
-                      #:properties properties))
-
-(module+ test
-  (test-case (name-string reducer-impersonate)
-    (test-case "properties only"
-      (define reducer (into-all-match? even?))
-      (define properties (hash impersonator-prop:contracted 'foo))
-      (define impersonated
-        (reducer-impersonate reducer #:properties properties))
-      (check-equal? (value-contract impersonated) 'foo)
-      (check-equal? impersonated reducer)
-      (check impersonator-of? impersonated reducer)
-      (check impersonator-of? reducer impersonated)
-      (check chaperone-of? impersonated reducer)
-      (check chaperone-of? reducer impersonated))
-    
-    (test-case "domain guard"
-      (define counter (box 0))
-      (define (guard v)
-        (set-box! counter (add1 (unbox counter)))
-        v)
-      (define impersonated
-        (reducer-impersonate into-list #:domain-guard guard #:chaperone? #true))
-      (check-equal? (reduce impersonated 'a 'b 'c) (list 'a 'b 'c))
-      (check-equal? (unbox counter) 3)
-      (check-equal? impersonated into-list)
-      (check impersonator-of? impersonated into-list)
-      (check-false (impersonator-of? into-list impersonated))
-      (check chaperone-of? impersonated into-list)
-      (check-false (chaperone-of? into-list impersonated)))
-
-    (test-case "range guard"
-      (define result (box #false))
-      (define (guard v)
-        (set-box! result v)
-        v)
-      (define impersonated
-        (reducer-impersonate into-list #:range-guard guard #:chaperone? #true))
-      (check-equal? (reduce impersonated 1 2 3) (list 1 2 3))
-      (check-equal? (unbox result) (list 1 2 3))
-      (check-equal? impersonated into-list)
-      (check impersonator-of? impersonated into-list)
-      (check-false (impersonator-of? into-list impersonated))
-      (check chaperone-of? impersonated into-list)
-      (check-false (chaperone-of? into-list impersonated)))))
-
-(define/name (reducer/c domain-contract* range-contract*)
-  (define domain-contract (coerce-contract enclosing-function-name domain-contract*))
-  (define range-contract (coerce-contract enclosing-function-name range-contract*))
-  (define contract-name
-    (build-compound-type-name enclosing-function-name domain-contract range-contract))
-  (define domain-projection (contract-late-neg-projection domain-contract))
-  (define range-projection (contract-late-neg-projection range-contract))
-  (define chaperone? (and (chaperone-contract? domain-contract) (chaperone-contract? range-contract)))
-  (define (projection blame)
-    (define domain-blame (blame-add-context blame "an element reduced by" #:swap? #true))
-    (define range-blame (blame-add-context blame "the reduction result of"))
-    (define late-neg-domain-guard (domain-projection domain-blame))
-    (define late-neg-range-guard (range-projection range-blame))
-    (λ (v missing-party)
-      (assert-satisfies v reducer? blame #:missing-party missing-party)
-      (define props
-        (hash impersonator-prop:contracted the-contract
-              impersonator-prop:blame (cons blame missing-party)))
-      (define (domain-guard v) (late-neg-domain-guard v missing-party))
-      (define (range-guard v) (late-neg-range-guard v missing-party))
-      (reducer-impersonate v
-                           #:domain-guard domain-guard
-                           #:range-guard range-guard
-                           #:chaperone? chaperone?
-                           #:properties props)))
-  (define the-contract
-    ((if chaperone? make-chaperone-contract make-contract)
-     #:name contract-name
-     #:first-order reducer?
-     #:late-neg-projection projection))
-  the-contract)
-
-(module+ test
-  (test-case (name-string reducer/c)
-    (test-case "should enforce the domain contract on sequence elements"
-      (define/contract reducer (reducer/c number? any/c) into-list)
-      (check-not-exn (λ () (reduce reducer 1 2 3)))
-      (define (bad) (reduce reducer 1 2 'foo 3))
-      (check-exn exn:fail:contract:blame? bad)
-      (check-exn #rx"expected: number\\?" bad)
-      (check-exn #rx"given: 'foo" bad)
-      (check-exn #rx"an element reduced by" bad))
-
-    (test-case "should enforce the range contract on reduction results"
-      (define/contract reducer (reducer/c any/c integer?) into-sum)
-      (check-not-exn (λ () (reduce reducer 1 2 3)))
-      (define (bad) (reduce reducer 1 2 3.5))
-      (check-exn exn:fail:contract:blame? bad)
-      (check-exn #rx"promised: integer\\?" bad)
-      (check-exn #rx"produced: 6\\.5" bad)
-      (check-exn #rx"the reduction result of" bad))))
 
 ;@------------------------------------------------------------------------------
 ;; Non-core APIs

--- a/streaming/reducer.scrbl
+++ b/streaming/reducer.scrbl
@@ -16,7 +16,8 @@
                      rebellion/collection/list
                      rebellion/streaming/reducer
                      rebellion/streaming/transducer
-                     rebellion/type/record)
+                     rebellion/type/record
+                     rebellion/type/tuple)
           (submod rebellion/private/scribble-evaluator-factory doc)
           (submod rebellion/private/scribble-cross-document-tech doc)
           scribble/example)
@@ -33,7 +34,8 @@
                    'rebellion/collection/list
                    'rebellion/streaming/reducer
                    'rebellion/streaming/transducer
-                   'rebellion/type/record)
+                   'rebellion/type/record
+                   'rebellion/type/tuple)
     #:private (list 'racket/base)))
 
 @title{Reducers}
@@ -510,6 +512,21 @@ reducers with increasing power and complexity:
    (define stringly-typed-into-sum
      (reducer-map into-sum #:domain string->number #:range number->string))
    (transduce (list "12" "5" "42" "17") #:into stringly-typed-into-sum))}
+
+
+@defproc[(reducer-zip [zip-function procedure?] [subreducer reducer?] ...) reducer?]{
+ Combines @racket[subreducer]s into a single reducer that applies @racket[zip-function] to the
+ reduction results of the subreducers. The given @racket[zip-function] must accept as many arguments
+ as there are @racket[subreducer]s. If every @racket[subreducer] finishes early, the combined reducer
+ finishes early.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (eval:no-prompt
+    (define-tuple-type endpoints (first last))
+    (define into-endpoints (reducer-zip endpoints nonempty-into-first nonempty-into-last)))
+
+   (transduce (list 1 2 3 4 5) #:into into-endpoints))}
 
 @defproc[(reducer-filter [red reducer?] [pred predicate/c]) reducer?]{
  Wraps @racket[red] to only reduce sequence elements for which @racket[pred]

--- a/streaming/reducer/private/base-test.rkt
+++ b/streaming/reducer/private/base-test.rkt
@@ -1,0 +1,78 @@
+#lang racket/base
+
+
+(module+ test
+  (require racket/contract/base
+           racket/contract/combinator
+           racket/contract/region
+           rackunit
+           rebellion/collection/list
+           rebellion/private/static-name
+           rebellion/streaming/reducer))
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(module+ test
+  (test-case (name-string reducer-impersonate)
+    (test-case "properties only"
+      (define reducer (into-all-match? even?))
+      (define properties (hash impersonator-prop:contracted 'foo))
+      (define impersonated
+        (reducer-impersonate reducer #:properties properties))
+      (check-equal? (value-contract impersonated) 'foo)
+      (check-equal? impersonated reducer)
+      (check impersonator-of? impersonated reducer)
+      (check impersonator-of? reducer impersonated)
+      (check chaperone-of? impersonated reducer)
+      (check chaperone-of? reducer impersonated))
+    
+    (test-case "domain guard"
+      (define counter (box 0))
+      (define (guard v)
+        (set-box! counter (add1 (unbox counter)))
+        v)
+      (define impersonated
+        (reducer-impersonate into-list #:domain-guard guard #:chaperone? #true))
+      (check-equal? (reduce impersonated 'a 'b 'c) (list 'a 'b 'c))
+      (check-equal? (unbox counter) 3)
+      (check-equal? impersonated into-list)
+      (check impersonator-of? impersonated into-list)
+      (check-false (impersonator-of? into-list impersonated))
+      (check chaperone-of? impersonated into-list)
+      (check-false (chaperone-of? into-list impersonated)))
+
+    (test-case "range guard"
+      (define result (box #false))
+      (define (guard v)
+        (set-box! result v)
+        v)
+      (define impersonated
+        (reducer-impersonate into-list #:range-guard guard #:chaperone? #true))
+      (check-equal? (reduce impersonated 1 2 3) (list 1 2 3))
+      (check-equal? (unbox result) (list 1 2 3))
+      (check-equal? impersonated into-list)
+      (check impersonator-of? impersonated into-list)
+      (check-false (impersonator-of? into-list impersonated))
+      (check chaperone-of? impersonated into-list)
+      (check-false (chaperone-of? into-list impersonated))))
+
+  (test-case (name-string reducer/c)
+    (test-case "should enforce the domain contract on sequence elements"
+      (define/contract reducer (reducer/c number? any/c) into-list)
+      (check-not-exn (λ () (reduce reducer 1 2 3)))
+      (define (bad) (reduce reducer 1 2 'foo 3))
+      (check-exn exn:fail:contract:blame? bad)
+      (check-exn #rx"expected: number\\?" bad)
+      (check-exn #rx"given: 'foo" bad)
+      (check-exn #rx"an element reduced by" bad))
+
+    (test-case "should enforce the range contract on reduction results"
+      (define/contract reducer (reducer/c any/c integer?) into-sum)
+      (check-not-exn (λ () (reduce reducer 1 2 3)))
+      (define (bad) (reduce reducer 1 2 3.5))
+      (check-exn exn:fail:contract:blame? bad)
+      (check-exn #rx"promised: integer\\?" bad)
+      (check-exn #rx"produced: 6\\.5" bad)
+      (check-exn #rx"the reduction result of" bad))))

--- a/streaming/reducer/private/base.rkt
+++ b/streaming/reducer/private/base.rkt
@@ -1,0 +1,63 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [reducer? predicate/c]
+  [make-reducer
+   (->*
+    (#:starter (-> reduction-state/c)
+     #:consumer (-> any/c any/c reduction-state/c)
+     #:finisher (-> any/c any/c)
+     #:early-finisher (-> any/c any/c))
+    (#:name (or/c interned-symbol? #false))
+    reducer?)]
+  [reducer-starter (-> reducer? (-> reduction-state/c))]
+  [reducer-consumer (-> reducer? (-> any/c any/c reduction-state/c))]
+  [reducer-finisher (-> reducer? (-> any/c any/c))]
+  [reducer-early-finisher (-> reducer? (-> any/c any/c))]))
+
+
+(module+ for-contracts
+  (provide descriptor:reducer))
+
+
+(require rebellion/base/symbol
+         rebellion/base/variant
+         rebellion/type/object)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define reduction-state/c (variant/c #:consume any/c #:early-finish any/c))
+
+
+(define-object-type reducer (starter consumer finisher early-finisher)
+  #:constructor-name constructor:reducer)
+
+
+(define (make-reducer #:starter starter*
+                      #:consumer consumer*
+                      #:finisher finisher*
+                      #:early-finisher early-finisher*
+                      #:name [name #false])
+  (define starter
+    (if (zero? (procedure-arity starter*)) starter* (procedure-reduce-arity starter* 0)))
+  (define consumer
+    (if (equal? (procedure-arity consumer*) 2) consumer* (procedure-reduce-arity consumer* 2)))
+  (define finisher
+    (if (equal? (procedure-arity finisher*) 1) finisher* (procedure-reduce-arity finisher* 1)))
+  (define early-finisher
+    (if (equal? (procedure-arity early-finisher*) 1)
+        early-finisher*
+        (procedure-reduce-arity early-finisher* 1)))
+  (constructor:reducer
+   #:starter starter
+   #:consumer consumer
+   #:finisher finisher
+   #:early-finisher early-finisher
+   #:name name))

--- a/streaming/reducer/private/base.rkt
+++ b/streaming/reducer/private/base.rkt
@@ -7,6 +7,7 @@
 (provide
  (contract-out
   [reducer? predicate/c]
+  [reducer/c (-> contract? contract? contract?)]
   [make-reducer
    (->*
     (#:starter (-> reduction-state/c)
@@ -18,15 +19,23 @@
   [reducer-starter (-> reducer? (-> reduction-state/c))]
   [reducer-consumer (-> reducer? (-> any/c any/c reduction-state/c))]
   [reducer-finisher (-> reducer? (-> any/c any/c))]
-  [reducer-early-finisher (-> reducer? (-> any/c any/c))]))
+  [reducer-early-finisher (-> reducer? (-> any/c any/c))]
+  [reducer-impersonate
+   (->* (reducer?)
+        (#:domain-guard (or/c (-> any/c any/c) #false)
+         #:range-guard (or/c (-> any/c any/c) #false)
+         #:properties impersonator-property-hash/c
+         #:chaperone? boolean?)
+        reducer?)]))
 
 
-(module+ for-contracts
-  (provide descriptor:reducer))
-
-
-(require rebellion/base/symbol
+(require racket/bool
+         racket/contract/combinator
+         rebellion/base/symbol
          rebellion/base/variant
+         rebellion/private/contract-projection
+         rebellion/private/impersonation
+         rebellion/private/static-name
          rebellion/type/object)
 
 
@@ -61,3 +70,82 @@
    #:finisher finisher
    #:early-finisher early-finisher
    #:name name))
+
+
+;@------------------------------------------------------------------------------
+;; Contracts
+
+(define ((reducer-consumer-guard domain-guard) state element)
+  (values state (domain-guard element)))
+
+(define (reducer-impersonate
+         reducer
+         #:domain-guard [domain-guard #false]
+         #:range-guard [range-guard #false]
+         #:properties [properties (hash)]
+         #:chaperone?
+         [chaperone? (and (false? domain-guard) (false? range-guard))])
+  (define consumer (reducer-consumer reducer))
+  (define finisher (reducer-finisher reducer))
+  (define early-finisher (reducer-early-finisher reducer))
+  (define domain-chaperone? (or chaperone? (false? domain-guard)))
+  (define range-chaperone? (or chaperone? (false? range-guard)))
+
+  (define impersonated-consumer
+    (function-impersonate
+     consumer
+     #:arguments-guard (and domain-guard (reducer-consumer-guard domain-guard))
+     #:chaperone? domain-chaperone?))
+
+  (define impersonated-finisher
+    (function-impersonate finisher
+                          #:results-guard range-guard
+                          #:chaperone? range-chaperone?))
+  
+  (define impersonated-early-finisher
+    (function-impersonate early-finisher
+                          #:results-guard range-guard
+                          #:chaperone? range-chaperone?))
+  
+  (define impersonated-without-props
+    (make-reducer #:starter (reducer-starter reducer)
+                  #:consumer impersonated-consumer
+                  #:finisher impersonated-finisher
+                  #:early-finisher impersonated-early-finisher
+                  #:name (object-name reducer)))
+  
+  (object-impersonate impersonated-without-props descriptor:reducer
+                      #:properties properties))
+
+
+(define/name (reducer/c domain-contract* range-contract*)
+  (define domain-contract (coerce-contract enclosing-function-name domain-contract*))
+  (define range-contract (coerce-contract enclosing-function-name range-contract*))
+  (define contract-name
+    (build-compound-type-name enclosing-function-name domain-contract range-contract))
+  (define domain-projection (contract-late-neg-projection domain-contract))
+  (define range-projection (contract-late-neg-projection range-contract))
+  (define chaperone? (and (chaperone-contract? domain-contract) (chaperone-contract? range-contract)))
+  (define (projection blame)
+    (define domain-blame (blame-add-context blame "an element reduced by" #:swap? #true))
+    (define range-blame (blame-add-context blame "the reduction result of"))
+    (define late-neg-domain-guard (domain-projection domain-blame))
+    (define late-neg-range-guard (range-projection range-blame))
+    (λ (v missing-party)
+      (assert-satisfies v reducer? blame #:missing-party missing-party)
+      (define props
+        (hash impersonator-prop:contracted the-contract
+              impersonator-prop:blame (cons blame missing-party)))
+      (define (domain-guard v) (late-neg-domain-guard v missing-party))
+      (define (range-guard v) (late-neg-range-guard v missing-party))
+      (reducer-impersonate v
+                           #:domain-guard domain-guard
+                           #:range-guard range-guard
+                           #:chaperone? chaperone?
+                           #:properties props)))
+  (define the-contract
+    ((if chaperone? make-chaperone-contract make-contract)
+     #:name contract-name
+     #:first-order reducer?
+     #:late-neg-projection projection))
+  the-contract)

--- a/streaming/reducer/private/zip-test.rkt
+++ b/streaming/reducer/private/zip-test.rkt
@@ -1,0 +1,33 @@
+#lang racket/base
+
+
+(module+ test
+  (require rackunit
+           rebellion/base/option
+           rebellion/private/static-name
+           rebellion/streaming/reducer
+           rebellion/streaming/transducer
+           rebellion/type/tuple))
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(module+ test
+  (test-case (name-string reducer-zip)
+
+    (test-case "no early finishing"
+      (define into-average (reducer-zip / into-sum into-count))
+      (check-equal? (transduce (list 1 2 3 4 5) #:into into-average) 3)
+      (check-equal? (transduce (list 2) #:into into-average) 2))
+
+    (test-case "one reducer finishes early"
+      (define-tuple-type endpoints (first last))
+      (define into-endpoints (reducer-zip endpoints nonempty-into-first nonempty-into-last))
+      (check-equal? (transduce (list 1 2 3 4 5) #:into into-endpoints) (endpoints 1 5)))
+
+    (test-case "all reducers finish early"
+      (define-tuple-type first-two-elements (first second))
+      (define into-first-two-elements (reducer-zip first-two-elements into-first (into-nth 1)))
+      (define actual (transduce (in-naturals) #:into into-first-two-elements))
+      (check-equal? actual (first-two-elements (present 0) (present 1))))))

--- a/streaming/reducer/private/zip.rkt
+++ b/streaming/reducer/private/zip.rkt
@@ -1,0 +1,96 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [reducer-zip
+   (->i
+    #:chaperone
+    ([zip-function procedure?])
+    #:rest [reducers (listof reducer?)]
+    #:pre/name (zip-function reducers)
+    "zip function arity must match up with the number of reducers given"
+    (procedure-arity-includes? zip-function (length reducers))
+    [_ reducer?])]))
+
+
+(require rebellion/base/variant
+         rebellion/private/static-name
+         rebellion/streaming/reducer/private/base
+         rebellion/type/record)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define-record-type zip-state (substate-values finished-reducers))
+
+
+(define/name (reducer-zip zip-function . reducers)
+  (define reducer-count (length reducers))
+  (define starters
+    (vector->immutable-vector
+     (for/vector #:length reducer-count ([reducer (in-list reducers)]) (reducer-starter reducer))))
+  (define consumers
+    (vector->immutable-vector
+     (for/vector #:length reducer-count ([reducer (in-list reducers)]) (reducer-consumer reducer))))
+  (define finishers
+    (vector->immutable-vector
+     (for/vector #:length reducer-count ([reducer (in-list reducers)]) (reducer-finisher reducer))))
+  (define early-finishers
+    (vector->immutable-vector
+     (for/vector #:length reducer-count
+       ([reducer (in-list reducers)])
+       (reducer-early-finisher reducer))))
+
+  (define (tag-state state)
+    (if (for/and ([finished-early? (in-vector (zip-state-finished-reducers state))]) finished-early?)
+        (variant #:early-finish state)
+        (variant #:consume state)))
+
+  (define (start)
+    (define substates (for/vector ([starter (in-vector starters)]) (starter)))
+    (define substate-values (for/vector ([substate (in-vector substates)]) (variant-value substate)))
+    (define finished-reducers
+      (for/vector ([substate (in-vector substates)]) (variant-tagged-as? substate '#:early-finish)))
+    (tag-state (zip-state #:substate-values substate-values #:finished-reducers finished-reducers)))
+
+  (define (consume state element)
+    (define substates (zip-state-substate-values state))
+    (define finished (zip-state-finished-reducers state))
+    (for ([i (in-range 0 reducer-count)])
+      (unless (vector-ref finished i)
+        (define substate (vector-ref substates i))
+        (define next-substate ((vector-ref consumers i) substate element))
+        (vector-set! substates i (variant-value next-substate))
+        (vector-set! finished i (variant-tagged-as? next-substate '#:early-finish))))
+    (tag-state state))
+
+  (define (finish state)
+    (define substates (zip-state-substate-values state))
+    (define finished (zip-state-finished-reducers state))
+    (define results
+      (for/list ([i (in-range 0 reducer-count)])
+        (define substate (vector-ref substates i))
+        (define finish-function (vector-ref (if (vector-ref finished i) early-finishers finishers) i))
+        (finish-function substate)))
+    (apply zip-function results))
+
+  (define (finish-early state)
+    (define substates (zip-state-substate-values state))
+    (define results
+      (for/list ([i (in-range 0 reducer-count)])
+        (define substate (vector-ref substates i))
+        (define finish-function (vector-ref early-finishers i))
+        (finish-function substate)))
+    (apply zip-function results))
+
+  (make-reducer
+   #:starter start
+   #:consumer consume
+   #:finisher finish
+   #:early-finisher finish-early
+   #:name 'zipped))


### PR DESCRIPTION
Closes #186. Went with a design where the zipped reducer finishes early if and only if *every* subreducer finishes early. This seems to work out for the common use cases, and I can't think of any use cases for finishing early when *any* subreducer finishes early.