### PR TITLE
Remove reprovide-lang dep

### DIFF
--- a/collection.rkt
+++ b/collection.rkt
@@ -1,1 +1,1 @@
-#lang reprovide
+#lang racket/base

--- a/collection/keyset.rkt
+++ b/collection/keyset.rkt
@@ -1,3 +1,7 @@
-#lang reprovide
-rebellion/collection/keyset/low-dependency
-rebellion/collection/keyset/private/reducer
+#lang racket/base
+
+(require rebellion/collection/keyset/low-dependency
+         rebellion/collection/keyset/private/reducer)
+
+(provide (all-from-out rebellion/collection/keyset/low-dependency
+                       rebellion/collection/keyset/private/reducer))

--- a/filter.rkt
+++ b/filter.rkt
@@ -1,2 +1,5 @@
-#lang reprovide
-rebellion/private/filter
+#lang racket/base
+
+(require rebellion/private/filter)
+
+(provide (all-from-out rebellion/private/filter))

--- a/info.rkt
+++ b/info.rkt
@@ -9,8 +9,7 @@
               "rebellion")))
 
 (define deps
-  (list "base"
-        "reprovide-lang"))
+  (list "base"))
 
 (define build-deps
   (list "net-doc"

--- a/main.rkt
+++ b/main.rkt
@@ -1,1 +1,1 @@
-#lang reprovide
+#lang racket/base

--- a/streaming/transducer.rkt
+++ b/streaming/transducer.rkt
@@ -1,13 +1,27 @@
-#lang reprovide
-rebellion/streaming/transducer/base
-rebellion/streaming/transducer/composition
-rebellion/streaming/transducer/private
-rebellion/streaming/transducer/private/batching
-rebellion/streaming/transducer/private/contract
-rebellion/streaming/transducer/private/deduplicating
-rebellion/streaming/transducer/private/enumerating
-rebellion/streaming/transducer/private/reducer
-rebellion/streaming/transducer/private/sorting
-rebellion/streaming/transducer/private/taking-duplicates
-rebellion/streaming/transducer/private/taking-maxima
-rebellion/streaming/transducer/private/windowing
+#lang racket/base
+
+(require rebellion/streaming/transducer/base
+         rebellion/streaming/transducer/composition
+         rebellion/streaming/transducer/private
+         rebellion/streaming/transducer/private/batching
+         rebellion/streaming/transducer/private/contract
+         rebellion/streaming/transducer/private/deduplicating
+         rebellion/streaming/transducer/private/enumerating
+         rebellion/streaming/transducer/private/reducer
+         rebellion/streaming/transducer/private/sorting
+         rebellion/streaming/transducer/private/taking-duplicates
+         rebellion/streaming/transducer/private/taking-maxima
+         rebellion/streaming/transducer/private/windowing)
+
+(provide (all-from-out rebellion/streaming/transducer/base
+                       rebellion/streaming/transducer/composition
+                       rebellion/streaming/transducer/private
+                       rebellion/streaming/transducer/private/batching
+                       rebellion/streaming/transducer/private/contract
+                       rebellion/streaming/transducer/private/deduplicating
+                       rebellion/streaming/transducer/private/enumerating
+                       rebellion/streaming/transducer/private/reducer
+                       rebellion/streaming/transducer/private/sorting
+                       rebellion/streaming/transducer/private/taking-duplicates
+                       rebellion/streaming/transducer/private/taking-maxima
+                       rebellion/streaming/transducer/private/windowing))

--- a/type/enum.rkt
+++ b/type/enum.rkt
@@ -1,4 +1,9 @@
-#lang reprovide
-rebellion/type/enum/base
-rebellion/type/enum/descriptor
-rebellion/type/enum/private/definition-macro
+#lang racket/base
+
+(require rebellion/type/enum/base
+         rebellion/type/enum/descriptor
+         rebellion/type/enum/private/definition-macro)
+
+(provide (all-from-out rebellion/type/enum/base
+                       rebellion/type/enum/descriptor
+                       rebellion/type/enum/private/definition-macro))

--- a/type/object.rkt
+++ b/type/object.rkt
@@ -1,4 +1,9 @@
-#lang reprovide
-rebellion/type/object/base
-rebellion/type/object/descriptor
-rebellion/type/object/private/definition-macro
+#lang racket/base
+
+(require rebellion/type/object/base
+         rebellion/type/object/descriptor
+         rebellion/type/object/private/definition-macro)
+
+(provide (all-from-out rebellion/type/object/base
+                       rebellion/type/object/descriptor
+                       rebellion/type/object/private/definition-macro))

--- a/type/record.rkt
+++ b/type/record.rkt
@@ -1,4 +1,9 @@
-#lang reprovide
-rebellion/type/record/base
-rebellion/type/record/descriptor
-rebellion/type/record/private/definition-macro
+#lang racket/base
+
+(require rebellion/type/record/base
+         rebellion/type/record/descriptor
+         rebellion/type/record/private/definition-macro)
+
+(provide (all-from-out rebellion/type/record/base
+                       rebellion/type/record/descriptor
+                       rebellion/type/record/private/definition-macro))

--- a/type/singleton.rkt
+++ b/type/singleton.rkt
@@ -1,4 +1,9 @@
-#lang reprovide
-rebellion/type/singleton/base
-rebellion/type/singleton/descriptor
-rebellion/type/singleton/private/definition-macro
+#lang racket/base
+
+(require rebellion/type/singleton/base
+         rebellion/type/singleton/descriptor
+         rebellion/type/singleton/private/definition-macro)
+
+(provide (all-from-out rebellion/type/singleton/base
+                       rebellion/type/singleton/descriptor
+                       rebellion/type/singleton/private/definition-macro))

--- a/type/tuple.rkt
+++ b/type/tuple.rkt
@@ -1,4 +1,9 @@
-#lang reprovide
-rebellion/type/tuple/base
-rebellion/type/tuple/descriptor
-rebellion/type/tuple/private/definition-macro
+#lang racket/base
+
+(require rebellion/type/tuple/base
+         rebellion/type/tuple/descriptor
+         rebellion/type/tuple/private/definition-macro)
+
+(provide (all-from-out rebellion/type/tuple/base
+                       rebellion/type/tuple/descriptor
+                       rebellion/type/tuple/private/definition-macro))

--- a/type/wrapper.rkt
+++ b/type/wrapper.rkt
@@ -1,4 +1,9 @@
-#lang reprovide
-rebellion/type/wrapper/base
-rebellion/type/wrapper/descriptor
-rebellion/type/wrapper/private/definition-macro
+#lang racket/base
+
+(require rebellion/type/wrapper/base
+         rebellion/type/wrapper/descriptor
+         rebellion/type/wrapper/private/definition-macro)
+
+(provide (all-from-out rebellion/type/wrapper/base
+                       rebellion/type/wrapper/descriptor
+                       rebellion/type/wrapper/private/definition-macro))


### PR DESCRIPTION
rebellion doesn't use any advanced features, so we can get away with a simple replacement with (require ...) (provide (all-from-out ...)).

Python (sorry!!!!) script I used to refactor:
```python
import subprocess

files = subprocess.run(["grep", "-rlZ", "#lang reprovide"], check=True, capture_output=True).stdout.split(b"\0")

for filename in files:
    if not filename:
        continue
    print(filename)
    with open(filename) as f:
        contents = f.read().split()
    if contents[:2] != ["#lang", "reprovide"]:
        print('not a reprovide file:', filename)
        continue

    contents = contents[2:]

    with open(filename, 'w', encoding='utf-8') as f:
        if contents:
            f.write("#lang racket/base"
                    + "\n\n(require "
                    + "\n         ".join(contents)
                    + ")\n"
                    + "\n(provide (all-from-out "
                    + "\n                       ".join(contents)
                    + "))\n")
        else:
            f.write("#lang racket/base\n")
```