### PR TITLE
Draft of attempts at better multiline string literals

### DIFF
--- a/private/at-exp-string-builders.rkt
+++ b/private/at-exp-string-builders.rkt
@@ -1,0 +1,29 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [line-string (-> any/c ... immutable-string?)]
+  [block-string (->* () (#:trailing-newline? boolean?) #:rest list? immutable-string?)]))
+
+
+(require racket/format
+         racket/string
+         rebellion/base/immutable-string)
+
+
+(define (line-string . parts)
+  (string->immutable-string
+   (string-trim (regexp-replace* #rx"\n+" (apply ~a parts) " ") #:repeat? #true)))
+
+
+(define (block-string #:trailing-newline? [trailing-newline? #true] . parts)
+  (define block (apply ~a parts))
+  (define contains-non-whitespace?
+    (for/or ([part (in-list parts)])
+      (not (equal? part "\n"))))
+  (string->immutable-string
+   (if (and trailing-newline? contains-non-whitespace?) (string-append block "\n") block)))

--- a/private/triple-quoted-string-test.rkt
+++ b/private/triple-quoted-string-test.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+
+(module+ main
+  #reader "triple-quoted-string.rkt"
+  """
+  hello world
+  how are you
+  """)

--- a/private/triple-quoted-string.rkt
+++ b/private/triple-quoted-string.rkt
@@ -1,0 +1,56 @@
+#lang racket/base
+
+
+(provide
+ (rename-out
+  [triple-quoted-string-read read]
+  [triple-quoted-string-read-syntax read-syntax]))
+
+
+(require racket/match
+         racket/string)
+
+
+(define (triple-quoted-string-read in)
+  (parameterize ([current-readtable (make-triple-quoted-string-readtable)])
+    (read in)))
+ 
+
+(define (triple-quoted-string-read-syntax src in)
+  (parameterize ([current-readtable (make-triple-quoted-string-readtable)])
+    (read-syntax src in)))
+ 
+
+(define (make-triple-quoted-string-readtable)
+  (make-readtable (current-readtable) #\" 'terminating-macro read-triple-string))
+
+
+(define read-triple-string
+  (case-lambda
+    [(ch in) (read-triple-string-datum ch in)]
+    [(ch in src line col pos) (read-triple-string-syntax ch in src line col pos)]))
+
+
+(define (read-triple-string-datum first-char in)
+  (define-values (_line col _pos) (port-next-location in))
+  (define initial-col (sub1 col))
+  (define result (regexp-match #rx"\"\"\n(.*)\"\"\"" in))
+  (define contents (match result [(list _ contents) (bytes->string/utf-8 contents)]))
+  (string->immutable-string
+   (string-join
+    (for/list ([line (in-lines (open-input-string contents))])
+      (substring line initial-col))
+    "\n")))
+  
+
+(define (read-triple-string-syntax first-char in src line col pos)
+  (define result (regexp-match #rx"\"\"\n(.*)\"\"\"" in))
+  (define contents (match result [(list _ contents) (bytes->string/utf-8 contents)]))
+  (define span (+ (string-length contents) 6))
+  (define dedented-contents
+    (string->immutable-string
+     (string-join
+      (for/list ([line (in-lines (open-input-string contents))])
+        (substring line col))
+      "\n")))
+  (datum->syntax #false dedented-contents (list src line col pos span)))

--- a/web-graph.rkt
+++ b/web-graph.rkt
@@ -1,4 +1,4 @@
-#lang racket/base
+#lang at-exp racket/base
 
 (require racket/contract/base)
 
@@ -14,10 +14,10 @@
 
 (module+ test
   (require (submod "..")
-           racket/format
            racket/port
            racket/pretty
-           rackunit))
+           rackunit
+           rebellion/private/at-exp-string-builders))
 
 ;@------------------------------------------------------------------------------
 
@@ -53,13 +53,11 @@
       (parameterize ([pretty-print-columns columns])
         (with-output-to-string
           (λ () (pretty-print v)))))
-    (check-equal? (~pretty graph #:columns 80)
-                  #<<END
-(web-graph
- (web-link "http://example.org" 'stylesheet "/styles.css")
- (web-link "http://example.org" 'stylesheet "/fonts.css")
- (web-link "http://example.org" 'search "/opensearch.xml")
- (web-link "http://example.org" 'privacy-policy "/privacy-policy"))
-
-END
-                  )))
+    (define expected
+      @block-string{
+        (web-graph
+          (web-link "http://example.org" 'stylesheet "/styles.css")
+          (web-link "http://example.org" 'stylesheet "/fonts.css")
+          (web-link "http://example.org" 'search "/opensearch.xml")
+          (web-link "http://example.org" 'privacy-policy "/privacy-policy"))})
+    (check-equal? (~pretty graph #:columns 80) expected)))


### PR DESCRIPTION
This is an experimental attempt to figure out a better way to work with multiline string literals. There's two use cases: _paragraphs_ and _text blocks_.

A paragraph is a string literal that spans multiple lines in the source code, but the actual written string is a one-line string. Use cases are long error messages that need to be split across multiple lines to stay under a reasonable column limit.

A text block is a string literal that spans multiple lines in the source code, where the total indentation of the the block doesn't matter but the relative indentation of each line does. Use cases are strings that contain multiple lines and have significant indentation and which are embedded in source code as expressions, such as the strings used in pretty printer test cases.

Approaches tried include @-expressions, here-strings, and a custom reader. Here-strings make it impossible to indent the whole string literal relative to the surrounding code, as the added indentation shows up in each line. @-expressions work great, except DrRacket wants to indent them like LaTeX-style macros within prose which breaks them. The custom reader approach is not finished, the idea is to have a meta-language which adds a new kind of string literal and an indenter that moves it around correctly.

I'm chucking this experiment into a closed pull request for now. I don't plan to put much more work into it (but I might anyway) and I just wanted a pull request to keep track of my thoughts and progress.