### PR TITLE
Add taking-local-maxima and taking-local-minima

### DIFF
--- a/streaming/transducer.rkt
+++ b/streaming/transducer.rkt
@@ -10,6 +10,7 @@
          rebellion/streaming/transducer/private/reducer
          rebellion/streaming/transducer/private/sorting
          rebellion/streaming/transducer/private/taking-duplicates
+         rebellion/streaming/transducer/private/taking-local-maxima
          rebellion/streaming/transducer/private/taking-maxima
          rebellion/streaming/transducer/private/windowing)
 
@@ -23,5 +24,6 @@
                        rebellion/streaming/transducer/private/reducer
                        rebellion/streaming/transducer/private/sorting
                        rebellion/streaming/transducer/private/taking-duplicates
+                       rebellion/streaming/transducer/private/taking-local-maxima
                        rebellion/streaming/transducer/private/taking-maxima
                        rebellion/streaming/transducer/private/windowing))

--- a/streaming/transducer.scrbl
+++ b/streaming/transducer.scrbl
@@ -270,6 +270,43 @@ early, before the input sequence is fully consumed.
               (taking-maxima #:key string-length)
               #:into into-list))}
 
+
+@deftogether[[
+ @defproc[
+ (taking-local-maxima
+  [comparator comparator? real<=>] [#:key key-function (-> any/c any/c) values])
+ transducer?]
+ @defproc[
+ (taking-local-minima
+  [comparator comparator? real<=>] [#:key key-function (-> any/c any/c) values])
+ transducer?]]]{
+ Constructs @tech{transducers} that remove all elements from the sequence except for the elements that
+ are larger than their neighbors (called the @emph{local maxima}) or smaller than their neighbors
+ (called the @emph{local minima}), respectively. If a subsequence of values are equivalent but larger
+ (or smaller) than the subsequence's neighbors, the last element of the subsequence is kept. The
+ relative order of the local maxima or minima is preserved.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (transduce (list 1 8 4 7 1)
+              (taking-local-maxima)
+              #:into into-list))
+
+ Elements are compared using @racket[comparator]. If @racket[key-function] is
+ provided, then elements are not compared directly. Instead, a @emph{key} is
+ extracted from each element using @racket[key-function] and the keys of
+ elements are compared instead of the elements themselves.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (transduce (list "cat" "dog" "aardvark" "zebra" "horse")
+              (taking-local-maxima string<=>)
+              #:into into-list)
+   (transduce (list "a" "long" "b" "longer" "longest" "c")
+              (taking-local-maxima #:key string-length)
+              #:into into-list))}
+
+
 @defproc[(taking-duplicates [#:key key-function (-> any/c any/c) values]) transducer?]{
  Constructs a @tech{transducer} that keeps only the duplicate elements of the transduced sequence.
  The first time an element occurs, it is removed from the sequence. Subsequent occurrences of that

--- a/streaming/transducer/private/taking-local-maxima-test.rkt
+++ b/streaming/transducer/private/taking-local-maxima-test.rkt
@@ -1,0 +1,141 @@
+#lang racket/base
+
+
+(module+ test
+  (require rackunit
+           rebellion/base/immutable-string
+           rebellion/collection/list
+           rebellion/private/static-name
+           rebellion/streaming/reducer
+           rebellion/streaming/transducer))
+
+
+;@------------------------------------------------------------------------------
+
+
+(module+ test
+
+  (test-case "taking-local-maxima"
+
+    (test-case "empty sequence"
+      (define actual (transduce '() (taking-local-maxima) #:into into-list))
+      (check-equal? actual '()))
+
+    (test-case "singleton sequence"
+      (define actual (transduce (list 1) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 1)))
+
+    (test-case "two-element ascending sequence"
+      (define actual (transduce (list 1 2) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 2)))
+
+    (test-case "two-element descending sequence"
+      (define actual (transduce (list 2 1) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 2)))
+
+    (test-case "three-element ascending sequence"
+      (define actual (transduce (list 1 2 3) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 3)))
+
+    (test-case "three-element descending sequence"
+      (define actual (transduce (list 3 2 1) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 3)))
+
+    (test-case "three-element peak sequence"
+      (define actual (transduce (list 1 3 2) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 3)))
+
+    (test-case "three-element valley sequence"
+      (define actual (transduce (list 3 1 2) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 3 2)))
+
+    (test-case "long alternating sequence"
+      (define actual (transduce (list 1 -1 2 -2 3 -3) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 1 2 3)))
+
+    (test-case "long ascending sequence"
+      (define actual (transduce (list 1 2 3 4 5) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 5)))
+
+    (test-case "long descending sequence"
+      (define actual (transduce (list 5 4 3 2 1) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 5)))
+
+    (test-case "sequence with plateau of maxima"
+      (define actual (transduce (list 1 2 3 3 2 1) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 3)))
+
+    (test-case "sequence with plateau of minima"
+      (define actual (transduce (list 3 2 1 1 2 3) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 3 3)))
+
+    (test-case "ascending sequence with plateau"
+      (define actual (transduce (list 1 2 3 3 4 5) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 5)))
+
+    (test-case "descending sequence with plateau"
+      (define actual (transduce (list 5 4 3 3 2 1) (taking-local-maxima) #:into into-list))
+      (check-equal? actual (list 5))))
+
+
+  (test-case "taking-local-minima"
+
+    (test-case "empty sequence"
+      (define actual (transduce '() (taking-local-minima) #:into into-list))
+      (check-equal? actual '()))
+
+    (test-case "singleton sequence"
+      (define actual (transduce (list 1) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1)))
+
+    (test-case "two-element ascending sequence"
+      (define actual (transduce (list 1 2) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1)))
+
+    (test-case "two-element descending sequence"
+      (define actual (transduce (list 2 1) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1)))
+
+    (test-case "three-element ascending sequence"
+      (define actual (transduce (list 1 2 3) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1)))
+
+    (test-case "three-element descending sequence"
+      (define actual (transduce (list 3 2 1) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1)))
+
+    (test-case "three-element peak sequence"
+      (define actual (transduce (list 1 3 2) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1 2)))
+
+    (test-case "three-element valley sequence"
+      (define actual (transduce (list 3 1 2) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1)))
+
+    (test-case "long alternating sequence"
+      (define actual (transduce (list 1 -1 2 -2 3 -3) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list -1 -2 -3)))
+
+    (test-case "long ascending sequence"
+      (define actual (transduce (list 1 2 3 4 5) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1)))
+
+    (test-case "long descending sequence"
+      (define actual (transduce (list 5 4 3 2 1) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1)))
+
+    (test-case "sequence with plateau of maxima"
+      (define actual (transduce (list 1 2 3 3 2 1) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1 1)))
+
+    (test-case "sequence with plateau of minima"
+      (define actual (transduce (list 3 2 1 1 2 3) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1)))
+
+    (test-case "ascending sequence with plateau"
+      (define actual (transduce (list 1 2 3 3 4 5) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1)))
+
+    (test-case "descending sequence with plateau"
+      (define actual (transduce (list 5 4 3 3 2 1) (taking-local-minima) #:into into-list))
+      (check-equal? actual (list 1)))))

--- a/streaming/transducer/private/taking-local-maxima.rkt
+++ b/streaming/transducer/private/taking-local-maxima.rkt
@@ -1,0 +1,84 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [taking-local-maxima (->* () (comparator? #:key (-> any/c any/c)) transducer?)]
+  [taking-local-minima (->* () (comparator? #:key (-> any/c any/c)) transducer?)]))
+
+
+(require racket/match
+         rebellion/base/comparator
+         rebellion/base/option
+         rebellion/base/variant
+         rebellion/streaming/transducer/base)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(struct local-maxima-consumption-state (previous-element previous-key ascending?) #:transparent)
+(struct local-maxima-emission-state (emission-element previous-element previous-key) #:transparent)
+
+
+(define (taking-local-maxima [comparator real<=>]
+                             #:key [key-function values]
+                             #:name [name 'taking-local-maxima])
+
+  (define (start)
+    (variant #:consume absent))
+
+  (define (consume state element)
+    (match state
+
+      [(== absent)
+       (variant
+        #:consume (present (local-maxima-consumption-state element (key-function element) #true)))]
+      
+      [(present (local-maxima-consumption-state previous-element previous-key #true))
+       (define key (key-function element))
+       (match (compare comparator key previous-key)
+         [(== lesser) (variant #:emit (local-maxima-emission-state previous-element element key))]
+         [_ (variant #:consume (present (local-maxima-consumption-state element key #true)))])]
+      
+      [(present (local-maxima-consumption-state previous-element previous-key #false))
+       (define key (key-function element))
+       (define ascending?
+       (match (compare comparator key previous-key)
+         [(== greater) #true]
+         [_ #false]))
+       (variant #:consume (present (local-maxima-consumption-state element key ascending?)))]))
+
+  (define (emit state)
+    (match-define (local-maxima-emission-state emission-element previous-element key) state)
+    (define next-state
+      (variant #:consume (present (local-maxima-consumption-state previous-element key #false))))
+    (emission next-state emission-element))
+
+  (define (half-close state)
+    (match state
+      [(== absent) (variant #:finish #false)]
+      [(present (local-maxima-consumption-state previous-element previous-key #true))
+       (variant #:half-closed-emit previous-element)]
+      [(present (local-maxima-consumption-state previous-element previous-key #false))
+       (variant #:finish #false)]))
+
+  (define (half-closed-emit element)
+    (half-closed-emission (variant #:finish #false) element))
+          
+  (make-transducer
+   #:starter start
+   #:consumer consume
+   #:emitter emit
+   #:half-closer half-close
+   #:half-closed-emitter half-closed-emit
+   #:finisher void
+   #:name name))
+
+
+(define (taking-local-minima [comparator real<=>] #:key [key-function values])
+  (taking-local-maxima
+   (comparator-reverse comparator) #:key key-function #:name 'taking-local-minima))


### PR DESCRIPTION
Note that for now these transducers just return the last element of plateaus, meaning that taking the local maxima of `(1 2 2 1 3 3 1)` yields `(2 3)` rather than `(2 2 3 3)`. This can be changed in the future in a backwards-compatible way by adding an argument to these functions that supplies a transducer to send plateaus into, with the current behavior implemented by using a transducer that takes the last element. I didn't bother to implement this functionality because it's not yet clear to me what the use cases for it are.