### PR TITLE
Add `transposing` transducer

### DIFF
--- a/base/variant.rkt
+++ b/base/variant.rkt
@@ -45,6 +45,7 @@
        (define tag-str (string-append "#:" (keyword->string tag)))
        (list (unquoted-printing-string tag-str) value))))
   (list (cons prop:custom-write custom-write)
+        (cons prop:custom-print-quotable 'never)
         (cons prop:equal+hash (default-tuple-equal+hash descriptor))))
 
 (define-tuple-type variant (tag value)

--- a/streaming/transducer.rkt
+++ b/streaming/transducer.rkt
@@ -12,6 +12,7 @@
          rebellion/streaming/transducer/private/taking-duplicates
          rebellion/streaming/transducer/private/taking-local-maxima
          rebellion/streaming/transducer/private/taking-maxima
+         rebellion/streaming/transducer/private/transposing
          rebellion/streaming/transducer/private/windowing)
 
 (provide (all-from-out rebellion/streaming/transducer/base
@@ -26,4 +27,5 @@
                        rebellion/streaming/transducer/private/taking-duplicates
                        rebellion/streaming/transducer/private/taking-local-maxima
                        rebellion/streaming/transducer/private/taking-maxima
+                       rebellion/streaming/transducer/private/transposing
                        rebellion/streaming/transducer/private/windowing))

--- a/streaming/transducer/private/transposing-test.rkt
+++ b/streaming/transducer/private/transposing-test.rkt
@@ -2,11 +2,14 @@
 
 
 (module+ test
-  (require rackunit
+  (require racket/sequence
+           racket/stream
+           rackunit
            rebellion/base/comparator
            rebellion/collection/list
            rebellion/private/static-name
            rebellion/streaming/transducer
+           rebellion/streaming/transducer/testing
            rebellion/type/record))
 
 
@@ -14,9 +17,311 @@
 
 (module+ test
   (test-case (name-string transposing)
-    (test-case "basic input with simple reducer"
-      (define actual
-        (transduce (list (list 1 2 3) (list 4 5 6) (list 7 8 9))
-                   (transposing #:into into-list)
-                   #:into into-list))
-      (check-equal? actual (list (list 1 4 7) (list 2 5 8) (list 3 6 9))))))
+
+    (test-case "nonterminating column reducer"
+
+      (test-case "no input"
+        (define actual
+          (transduce '()
+                     (observing-transduction-events (transposing #:into into-list))
+                     #:into into-list))
+        (check-equal? actual (list start-event half-close-event finish-event)))
+
+      (test-case "single empty list"
+        (define actual
+          (transduce (list '())
+                     (observing-transduction-events (transposing #:into into-list))
+                     #:into into-list))
+        (check-equal? actual (list start-event (consume-event '()) finish-event)))
+
+      (test-case "multiple empty lists"
+        (define actual
+          (transduce (list '() '() '())
+                     (observing-transduction-events (transposing #:into into-list))
+                     #:into into-list))
+        (define expected
+          (list start-event (consume-event '()) finish-event))
+        (check-equal? actual expected))
+
+      (test-case "infinite empty lists"
+        (define actual
+          (transduce (for/stream ([_ (in-naturals)])
+                       '())
+                     (observing-transduction-events (transposing #:into into-list))
+                     #:into into-list))
+        (define expected
+          (list start-event (consume-event '()) finish-event))
+        (check-equal? actual expected))
+
+      (test-case "single list"
+        (define actual
+          (transduce (list (list 1 2 3))
+                     (observing-transduction-events (transposing #:into into-list))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1 2 3))
+                half-close-event
+                (half-closed-emit-event (list 1))
+                (half-closed-emit-event (list 2))
+                (half-closed-emit-event (list 3))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple singleton lists"
+        (define actual
+          (transduce (list (list 1) (list 2) (list 3))
+                     (observing-transduction-events (transposing #:into into-list))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1))
+                (consume-event (list 2))
+                (consume-event (list 3))
+                half-close-event
+                (half-closed-emit-event (list 1 2 3))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple lists"
+        (define actual
+          (transduce (list (list 1 2 3) (list 4 5 6) (list 7 8 9))
+                     (observing-transduction-events (transposing #:into into-list))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1 2 3))
+                (consume-event (list 4 5 6))
+                (consume-event (list 7 8 9))
+                half-close-event
+                (half-closed-emit-event (list 1 4 7))
+                (half-closed-emit-event (list 2 5 8))
+                (half-closed-emit-event (list 3 6 9))
+                finish-event))
+        (check-equal? actual expected)))
+
+    (test-case "terminating reducer"
+
+      (define into-list-until-stop
+        (into-transduced (taking-while (λ (x) (not (equal? x 'stop)))) #:into into-list))
+
+      (test-case "no input"
+        (define actual
+          (transduce '()
+                     (observing-transduction-events (transposing #:into into-list-until-stop))
+                     #:into into-list))
+        (define expected (list start-event half-close-event finish-event))
+        (check-equal? actual expected))
+
+      (test-case "single empty list"
+        (define actual
+          (transduce (list '())
+                     (observing-transduction-events (transposing #:into into-list-until-stop))
+                     #:into into-list))
+        (define expected (list start-event (consume-event '()) finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple empty lists"
+        (define actual
+          (transduce (list '() '() '())
+                     (observing-transduction-events (transposing #:into into-list-until-stop))
+                     #:into into-list))
+        (define expected (list start-event (consume-event '()) finish-event))
+        (check-equal? actual expected))
+
+      (test-case "infinite empty lists"
+        (define actual
+          (transduce (for/stream ([_ (in-naturals)])
+                       '())
+                     (observing-transduction-events (transposing #:into into-list-until-stop))
+                     #:into into-list))
+        (define expected (list start-event (consume-event '()) finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple singleton lists"
+        (define actual
+          (transduce (list (list 1) (list 2) (list 3))
+                     (observing-transduction-events (transposing #:into into-list-until-stop))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1))
+                (consume-event (list 2))
+                (consume-event (list 3))
+                half-close-event
+                (half-closed-emit-event (list 1 2 3))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple singleton lists with stop"
+        (define actual
+          (transduce (list (list 1) (list 2) (list 3) (list 'stop) (list 4))
+                     (observing-transduction-events (transposing #:into into-list-until-stop))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1))
+                (consume-event (list 2))
+                (consume-event (list 3))
+                (consume-event (list 'stop))
+                (half-closed-emit-event (list 1 2 3))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "infinite singleton lists with stop"
+        (define input
+          (sequence-append
+           (list (list 1) (list 2) (list 3) (list 'stop))
+           (for/stream ([n (in-naturals 4)])
+             (list n))))
+        (define actual
+          (transduce input
+                     (observing-transduction-events (transposing #:into into-list-until-stop))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1))
+                (consume-event (list 2))
+                (consume-event (list 3))
+                (consume-event (list 'stop))
+                (half-closed-emit-event (list 1 2 3))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple lists"
+        (define actual
+          (transduce (list (list 1 2 3) (list 4 5 6) (list 7 8 9))
+                     (observing-transduction-events (transposing #:into into-list-until-stop))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1 2 3))
+                (consume-event (list 4 5 6))
+                (consume-event (list 7 8 9))
+                half-close-event
+                (half-closed-emit-event (list 1 4 7))
+                (half-closed-emit-event (list 2 5 8))
+                (half-closed-emit-event (list 3 6 9))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple lists with first column stopping"
+        (define actual
+          (transduce (list (list 1 2 3) (list 'stop 5 6) (list 7 8 9))
+                     (observing-transduction-events (transposing #:into into-list-until-stop))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1 2 3))
+                (consume-event (list 'stop 5 6))
+                (emit-event (list 1))
+                (consume-event (list 7 8 9))
+                half-close-event
+                (half-closed-emit-event (list 2 5 8))
+                (half-closed-emit-event (list 3 6 9))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple lists with first column stopping with unordered columns"
+        (define actual
+          (transduce (list (list 1 2 3) (list 'stop 5 6) (list 7 8 9))
+                     (observing-transduction-events
+                      (transposing #:into into-list-until-stop #:ordered? #false))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1 2 3))
+                (consume-event (list 'stop 5 6))
+                (emit-event (list 1))
+                (consume-event (list 7 8 9))
+                half-close-event
+                (half-closed-emit-event (list 2 5 8))
+                (half-closed-emit-event (list 3 6 9))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple lists with last column stopping"
+        (define actual
+          (transduce (list (list 1 2 3) (list 4 5 'stop) (list 7 8 9))
+                     (observing-transduction-events (transposing #:into into-list-until-stop))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1 2 3))
+                (consume-event (list 4 5 'stop))
+                (consume-event (list 7 8 9))
+                half-close-event
+                (half-closed-emit-event (list 1 4 7))
+                (half-closed-emit-event (list 2 5 8))
+                (half-closed-emit-event (list 3))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple lists with last column stopping with unordered columns"
+        (define actual
+          (transduce (list (list 1 2 3) (list 4 5 'stop) (list 7 8 9))
+                     (observing-transduction-events
+                      (transposing #:into into-list-until-stop #:ordered? #false))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1 2 3))
+                (consume-event (list 4 5 'stop))
+                (emit-event (list 3))
+                (consume-event (list 7 8 9))
+                half-close-event
+                (half-closed-emit-event (list 1 4 7))
+                (half-closed-emit-event (list 2 5 8))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple lists with all stopping simultaneously"
+        (define actual
+          (transduce (list (list 1 2 3) (list 'stop 'stop 'stop) (list 7 8 9))
+                     (observing-transduction-events (transposing #:into into-list-until-stop))
+                     #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1 2 3))
+                (consume-event (list 'stop 'stop 'stop))
+                (half-closed-emit-event (list 1))
+                (half-closed-emit-event (list 2))
+                (half-closed-emit-event (list 3))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple lists with all stopping separately"
+        (define actual
+          (transduce
+           (list (list 1 2 3) (list 4 'stop 6) (list 'stop 8 9) (list 0 0 'stop) (list 0 0 0))
+           (observing-transduction-events (transposing #:into into-list-until-stop))
+           #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1 2 3))
+                (consume-event (list 4 'stop 6))
+                (consume-event (list 'stop 8 9))
+                (emit-event (list 1 4))
+                (emit-event (list 2))
+                (consume-event (list 0 0 'stop))
+                (half-closed-emit-event (list 3 6 9))
+                finish-event))
+        (check-equal? actual expected))
+
+      (test-case "multiple lists with all stopping separately with unordered columns"
+        (define actual
+          (transduce
+           (list (list 1 2 3) (list 4 'stop 6) (list 'stop 8 9) (list 0 0 'stop) (list 0 0 0))
+           (observing-transduction-events (transposing #:into into-list-until-stop #:ordered? #false))
+           #:into into-list))
+        (define expected
+          (list start-event
+                (consume-event (list 1 2 3))
+                (consume-event (list 4 'stop 6))
+                (emit-event (list 2))
+                (consume-event (list 'stop 8 9))
+                (emit-event (list 1 4))
+                (consume-event (list 0 0 'stop))
+                (half-closed-emit-event (list 3 6 9))
+                finish-event))
+        (check-equal? actual expected)))))

--- a/streaming/transducer/private/transposing-test.rkt
+++ b/streaming/transducer/private/transposing-test.rkt
@@ -1,0 +1,22 @@
+#lang racket/base
+
+
+(module+ test
+  (require rackunit
+           rebellion/base/comparator
+           rebellion/collection/list
+           rebellion/private/static-name
+           rebellion/streaming/transducer
+           rebellion/type/record))
+
+
+;@----------------------------------------------------------------------------------------------------
+
+(module+ test
+  (test-case (name-string transposing)
+    (test-case "basic input with simple reducer"
+      (define actual
+        (transduce (list (list 1 2 3) (list 4 5 6) (list 7 8 9))
+                   (transposing #:into into-list)
+                   #:into into-list))
+      (check-equal? actual (list (list 1 4 7) (list 2 5 8) (list 3 6 9))))))

--- a/streaming/transducer/private/transposing.rkt
+++ b/streaming/transducer/private/transposing.rkt
@@ -1,0 +1,140 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [transposing (-> #:into reducer? transducer?)]))
+
+
+(require racket/match
+         rebellion/base/variant
+         rebellion/collection/vector
+         rebellion/private/guarded-block
+         rebellion/private/static-name
+         rebellion/streaming/reducer
+         rebellion/streaming/transducer/base)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(struct transposing-state (reduction-state-vector [previous-emission #:mutable]))
+
+
+(define (make-first-state seq starter)
+  (define elems (sequence->vector seq))
+  (define states
+    (for/vector ([_ (in-vector elems)])
+      (starter)))
+  (transposing-state states #false))
+
+
+(define (transposing-state-consume-sequence! state seq consumer)
+  (define state-vec (transposing-state-reduction-state-vector state))
+  (define max-length (vector-length state-vec))
+  (define seq-length
+    (for/fold ([seq-length 0])
+              ([v seq]
+               [i (in-naturals)])
+      (unless (< i max-length)
+        (raise-arguments-error
+         (name transposing)
+         "transposed sequences not all the same length\n later sequence longer than first sequence"
+         "first sequence length" max-length
+         "later sequence" seq))
+      (match (vector-ref state-vec i)
+        [(variant #:consume state)
+         (vector-set! state-vec i (consumer state v))]
+        [(or (variant #:early-finish _) #false)
+         (void)])
+      (add1 seq-length)))
+  (unless (equal? seq-length max-length)
+    (raise-arguments-error
+     (name transposing)
+     "transposed sequences not all the same length\n later sequence shorter than first sequence"
+     "first sequence length" max-length
+     "later sequence" seq)))
+
+
+(define/guard (transposing-state-next-action state)
+  (match-define (transposing-state state-vec previous-emission) state)
+  (define scan-start (if previous-emission (add1 previous-emission) 0))
+  (define state-count (vector-length state-vec))
+  (let loop ([i scan-start])
+    (guarded-block
+      (guard (equal? i state-count) then
+        (set-transposing-state-previous-emission! state #false)
+        (variant #:consume state))
+      (match (vector-ref state-vec i)
+        [(variant #:early-finish _)
+         (set-transposing-state-previous-emission! state i)
+         (variant #:emit state)]
+        [(or #false (variant #:consume _))
+         (loop (add1 i))]))))
+
+
+(define (transposing-state-emit! state early-finisher)
+  (match-define (transposing-state state-vec previous-emission) state)
+  (match-define (variant #:early-finish substate) (vector-ref state-vec previous-emission))
+  (define result (early-finisher substate))
+  (vector-set! state-vec previous-emission #false)
+  (emission (transposing-state-next-action state) result))
+
+
+(define (transposing-state-next-half-closed-action state)
+  (match-define (transposing-state state-vec previous-emission) state)
+  (define scan-start (if previous-emission (add1 previous-emission) 0))
+  (define state-count (vector-length state-vec))
+  (let loop ([i scan-start])
+    (guarded-block
+      (guard (equal? i state-count) then
+        (variant #:finish #false))
+      (match (vector-ref state-vec i)
+        [(variant #:consume _)
+         (set-transposing-state-previous-emission! state i)
+         (variant #:half-closed-emit state)]
+        [#false (loop (add1 i))]))))
+
+
+(define (transposing-state-half-closed-emit! state finisher)
+  (match-define (transposing-state state-vec previous-emission) state)
+  (match-define (variant #:consume substate) (vector-ref state-vec previous-emission))
+  (define result (finisher substate))
+  (vector-set! state-vec previous-emission #false)
+  (half-closed-emission (transposing-state-next-half-closed-action state) result))
+
+
+(define (transposing #:into transposition-reducer)
+  (define transposition-starter (reducer-starter transposition-reducer))
+  (define transposition-consumer (reducer-consumer transposition-reducer))
+  (define transposition-early-finisher (reducer-early-finisher transposition-reducer))
+  (define transposition-finisher (reducer-finisher transposition-reducer))
+
+  (define (start)
+    (variant #:consume #false))
+
+  (define (consume state seq)
+    (let ([state (or state (make-first-state seq transposition-starter))])
+      (transposing-state-consume-sequence! state seq transposition-consumer)
+      (transposing-state-next-action state)))
+
+  (define (emit state)
+    (transposing-state-emit! state transposition-early-finisher))
+
+  (define (half-close state)
+    (transposing-state-next-half-closed-action state))
+
+  (define (half-closed-emit state)
+    (transposing-state-half-closed-emit! state transposition-finisher))
+
+  (make-transducer
+   #:starter start
+   #:consumer consume
+   #:emitter emit
+   #:half-closer half-close
+   #:half-closed-emitter half-closed-emit
+   #:finisher void
+   #:name (name transposing)))

--- a/streaming/transducer/private/transposing.rkt
+++ b/streaming/transducer/private/transposing.rkt
@@ -6,7 +6,8 @@
 
 (provide
  (contract-out
-  [transposing (-> #:into reducer? (transducer/c (sequence/c any/c) any/c))]))
+  [transposing
+   (->* (#:into reducer?) (#:ordered? boolean?) (transducer/c (sequence/c any/c) any/c))]))
 
 
 (require racket/match
@@ -23,7 +24,35 @@
 ;@----------------------------------------------------------------------------------------------------
 
 
-(struct transposing-state (reduction-state-vector [previous-emission #:mutable]))
+(struct transposing-state
+  (reduction-state-vector
+   [first-consuming #:mutable]
+   [first-finished-early #:mutable])
+  #:transparent)
+
+
+(define (transposing-state-find-first-consuming! state)
+  (define states (transposing-state-reduction-state-vector state))
+  (define state-count (vector-length states))
+  (define scan-start (or (transposing-state-first-consuming state) 0))
+  (define first-consuming
+    (for/first ([s (in-vector states scan-start)]
+                [i (in-naturals scan-start)]
+                #:when (and (variant? s) (variant-tagged-as? s '#:consume)))
+      i))
+  (set-transposing-state-first-consuming! state first-consuming))
+
+
+(define (transposing-state-find-first-finished-early! state)
+  (define states (transposing-state-reduction-state-vector state))
+  (define state-count (vector-length states))
+  (define scan-start (or (transposing-state-first-finished-early state) 0))
+  (define first-finished-early
+    (for/first ([s (in-vector states scan-start)]
+                [i (in-naturals scan-start)]
+                #:when (and (variant? s) (variant-tagged-as? s '#:early-finish)))
+      i))
+  (set-transposing-state-first-finished-early! state first-finished-early))
 
 
 (define (make-first-state seq starter)
@@ -31,7 +60,10 @@
   (define states
     (for/vector ([_ (in-vector elems)])
       (starter)))
-  (transposing-state states #false))
+  (define state (transposing-state states #false #false))
+  (transposing-state-find-first-consuming! state)
+  (transposing-state-find-first-finished-early! state)
+  state)
 
 
 (define (transposing-state-consume-sequence! state seq consumer)
@@ -58,58 +90,96 @@
      (name transposing)
      "transposed sequences not all the same length\n later sequence shorter than first sequence"
      "first sequence length" max-length
-     "later sequence" seq)))
+     "later sequence" seq))
+  (set-transposing-state-first-consuming! state #false)
+  (set-transposing-state-first-finished-early! state #false)
+  (transposing-state-find-first-consuming! state)
+  (transposing-state-find-first-finished-early! state))
 
 
-(define/guard (transposing-state-next-action state)
-  (match-define (transposing-state state-vec previous-emission) state)
-  (define scan-start (if previous-emission (add1 previous-emission) 0))
-  (define state-count (vector-length state-vec))
-  (let loop ([i scan-start])
-    (guarded-block
-      (guard (equal? i state-count) then
-        (set-transposing-state-previous-emission! state #false)
-        (variant #:consume state))
-      (match (vector-ref state-vec i)
-        [(variant #:early-finish _)
-         (set-transposing-state-previous-emission! state i)
-         (variant #:emit state)]
-        [(or #false (variant #:consume _))
-         (loop (add1 i))]))))
+(define/guard (transposing-state-next-action-unordered state)
+  (match-define (transposing-state _ first-consuming first-finished-early) state)
+  (cond
+    [(and first-consuming first-finished-early) (variant #:emit state)]
+    [first-finished-early (variant #:half-closed-emit state)]
+    [first-consuming (variant #:consume state)]
+    [else (variant #:finish #false)]))
+
+
+(define/guard (transposing-state-next-action-ordered state)
+  (match-define (transposing-state _ first-consuming first-finished-early) state)
+  (cond
+    [(and first-consuming first-finished-early)
+     (if (< first-finished-early first-consuming) (variant #:emit state) (variant #:consume state))]
+    [first-finished-early (variant #:half-closed-emit state)]
+    [first-consuming (variant #:consume state)]
+    [else (variant #:finish #false)]))
 
 
 (define (transposing-state-emit! state early-finisher)
-  (match-define (transposing-state state-vec previous-emission) state)
-  (match-define (variant #:early-finish substate) (vector-ref state-vec previous-emission))
+  (match-define (transposing-state state-vec _ first-finished-early) state)
+  (match-define (variant #:early-finish substate) (vector-ref state-vec first-finished-early))
   (define result (early-finisher substate))
-  (vector-set! state-vec previous-emission #false)
-  (emission (transposing-state-next-action state) result))
+  (vector-set! state-vec first-finished-early #false)
+  (transposing-state-find-first-finished-early! state)
+  (emission (transposing-state-next-action-unordered state) result))
 
 
-(define (transposing-state-next-half-closed-action state)
-  (match-define (transposing-state state-vec previous-emission) state)
-  (define scan-start (if previous-emission (add1 previous-emission) 0))
-  (define state-count (vector-length state-vec))
-  (let loop ([i scan-start])
-    (guarded-block
-      (guard (equal? i state-count) then
-        (variant #:finish #false))
-      (match (vector-ref state-vec i)
-        [(variant #:consume _)
-         (set-transposing-state-previous-emission! state i)
-         (variant #:half-closed-emit state)]
-        [#false (loop (add1 i))]))))
+(define (transposing-state-next-half-closed-action-unordered state)
+  (match-define (transposing-state _ first-consuming #false) state)
+  (if first-consuming
+      (variant #:half-closed-emit state)
+      (variant #:finish #false)))
 
 
-(define (transposing-state-half-closed-emit! state finisher)
-  (match-define (transposing-state state-vec previous-emission) state)
-  (match-define (variant #:consume substate) (vector-ref state-vec previous-emission))
-  (define result (finisher substate))
-  (vector-set! state-vec previous-emission #false)
-  (half-closed-emission (transposing-state-next-half-closed-action state) result))
+(define (transposing-state-next-half-closed-action-ordered state)
+  (match-define (transposing-state _ first-consuming first-finished-early) state)
+  (if (or first-consuming first-finished-early)
+      (variant #:half-closed-emit state)
+      (variant #:finish #false)))
 
 
-(define (transposing #:into transposition-reducer)
+(define (transposing-state-half-closed-emit-unordered! state finisher early-finisher)
+  (match state
+    [(transposing-state state-vec first-consuming #false)
+     (match-define (variant #:consume substate) (vector-ref state-vec first-consuming))
+     (define result (finisher substate))
+     (vector-set! state-vec first-consuming #false)
+     (transposing-state-find-first-consuming! state)
+     (half-closed-emission (transposing-state-next-half-closed-action-unordered state) result)]
+    [(transposing-state state-vec #false first-finished-early)
+     (match-define (variant #:early-finish substate) (vector-ref state-vec first-finished-early))
+     (define result (early-finisher substate))
+     (vector-set! state-vec first-finished-early #false)
+     (transposing-state-find-first-finished-early! state)
+     (half-closed-emission (transposing-state-next-half-closed-action-ordered state) result)]))
+
+
+(define (transposing-state-half-closed-emit-ordered! state finisher early-finisher)
+  (match-define (transposing-state state-vec first-consuming first-finished-early) state)
+  (cond
+    [(< (or first-consuming +inf.0) (or first-finished-early +inf.0))
+     (match-define (variant #:consume substate) (vector-ref state-vec first-consuming))
+     (define result (finisher substate))
+     (vector-set! state-vec first-consuming #false)
+     (transposing-state-find-first-consuming! state)
+     (half-closed-emission (transposing-state-next-half-closed-action-ordered state) result)]
+    [(< (or first-finished-early +inf.0) (or first-consuming +inf.0))
+     (match-define (variant #:early-finish substate) (vector-ref state-vec first-finished-early))
+     (define result (early-finisher substate))
+     (vector-set! state-vec first-finished-early #false)
+     (transposing-state-find-first-finished-early! state)
+     (half-closed-emission (transposing-state-next-half-closed-action-ordered state) result)]
+    [else
+     (raise-arguments-error
+      (name transposing-state-half-closed-emit-ordered!)
+      "this combination of first-consuming and first-finished-early should be impossible"
+      "first-consuming" first-consuming
+      "first-finished-early" first-finished-early
+      "state vector" state-vec)]))
+
+
+(define (transposing #:into transposition-reducer #:ordered? [ordered? #true])
   (define transposition-starter (reducer-starter transposition-reducer))
   (define transposition-consumer (reducer-consumer transposition-reducer))
   (define transposition-early-finisher (reducer-early-finisher transposition-reducer))
@@ -118,19 +188,39 @@
   (define (start)
     (variant #:consume #false))
 
-  (define (consume state seq)
-    (let ([state (or state (make-first-state seq transposition-starter))])
-      (transposing-state-consume-sequence! state seq transposition-consumer)
-      (transposing-state-next-action state)))
+  (define consume
+    (if ordered?
+        (λ (state seq)
+          (let ([state (or state (make-first-state seq transposition-starter))])
+            (transposing-state-consume-sequence! state seq transposition-consumer)
+            (transposing-state-next-action-ordered state)))
+        (λ (state seq)
+          (let ([state (or state (make-first-state seq transposition-starter))])
+            (transposing-state-consume-sequence! state seq transposition-consumer)
+            (transposing-state-next-action-unordered state)))))
 
   (define (emit state)
     (transposing-state-emit! state transposition-early-finisher))
 
-  (define (half-close state)
-    (transposing-state-next-half-closed-action state))
+  (define half-close
+    (if ordered?
+        (λ (state)
+          (if state
+              (transposing-state-next-half-closed-action-ordered state)
+              (variant #:finish #false)))
+        (λ (state)
+          (if state
+              (transposing-state-next-half-closed-action-unordered state)
+              (variant #:finish #false)))))
 
-  (define (half-closed-emit state)
-    (transposing-state-half-closed-emit! state transposition-finisher))
+  (define half-closed-emit
+    (if ordered?
+        (λ (state)
+          (transposing-state-half-closed-emit-ordered!
+           state transposition-finisher transposition-early-finisher))
+        (λ (state)
+          (transposing-state-half-closed-emit-unordered!
+           state transposition-finisher transposition-early-finisher))))
 
   (make-transducer
    #:starter start

--- a/streaming/transducer/private/transposing.rkt
+++ b/streaming/transducer/private/transposing.rkt
@@ -6,16 +6,18 @@
 
 (provide
  (contract-out
-  [transposing (-> #:into reducer? transducer?)]))
+  [transposing (-> #:into reducer? (transducer/c (sequence/c any/c) any/c))]))
 
 
 (require racket/match
+         racket/sequence
          rebellion/base/variant
          rebellion/collection/vector
          rebellion/private/guarded-block
          rebellion/private/static-name
          rebellion/streaming/reducer
-         rebellion/streaming/transducer/base)
+         rebellion/streaming/transducer/base
+         rebellion/streaming/transducer/private/contract)
 
 
 ;@----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Given a list of lists, a common Racket idiom to _transpose_ the lists is `(apply map list list-of-lists)`. This transforms `'((1 2 3) (a b c) (x y z))` into `'((1 a x) (2 b y) (3 c z))`. This pull request adds a `transposing` transducer that generalizes this operation to any sequence of sequences, allowing one to transpose a list-of-sequences into a vector-of-vectors, for example.