### PR TITLE
Add data type guards

### DIFF
--- a/type/record/private/definition-macro.rkt
+++ b/type/record/private/definition-macro.rkt
@@ -77,7 +77,12 @@
      (~optional
       (~seq #:property-maker prop-maker:expr)
       #:defaults ([prop-maker #'default-record-properties])
-      #:name "#:property-maker option"))
+      #:name "#:property-maker option")
+
+     (~optional
+      (~seq #:guard-maker guard-maker:expr)
+      #:defaults ([guard-maker #'#f])
+      #:name "#:guard-maker option"))
     ...)
   
   #:with (field-accessor ...)
@@ -113,7 +118,8 @@
         #:constructor-name 'constructor
         #:accessor-name 'accessor)
        #:inspector inspector
-       #:property-maker prop-maker))
+       #:property-maker prop-maker
+       #:guard-maker guard-maker))
     (define predicate (record-descriptor-predicate descriptor))
     (define constructor (record-descriptor-constructor descriptor))
     (define accessor (record-descriptor-accessor descriptor))

--- a/type/tuple.scrbl
+++ b/type/tuple.scrbl
@@ -117,10 +117,10 @@ represent a single logical thing, and there is an obvious order to those pieces.
  such as when creating a smart constructor.
 
  The @racket[prop-maker-expr] is used to add structure type properties to the
- created type, @racket[guard-expr] is used to attach guards to the tuple constructor
- and @racket[inspector-expr] is used to determine the @tech/reference{inspector}
- that will control the created type. See @racket[make-tuple-implementation]
- for more information about these parameters.
+ created type, @racket[guard-maker-expr] is used to create the guard procedure, and
+ @racket[inspector-expr] is used to determine the @tech/reference{inspector} that
+ will control the created type. See @racket[make-tuple-implementation] for more
+ information about these parameters.
  
  @(examples
    #:eval (make-evaluator) #:once
@@ -207,7 +207,8 @@ field in the tuple: the per-field accessors created by
    (-> uninitialized-tuple-descriptor?
        (listof (cons/c struct-type-property? any/c)))
    default-tuple-properties]
-  [#:guard-maker (or/c #f (-> uninitialized-tuple-descriptor? procedure?)) #f])
+  [#:guard-maker guard-maker
+   (or/c #f (-> uninitialized-tuple-descriptor? procedure?)) #f])
  initialized-tuple-descriptor?]{
  Implements @racket[type] and returns a @tech{type descriptor} for the new
  implementation.
@@ -244,7 +245,7 @@ field in the tuple: the per-field accessors created by
  Returns a procedure suitable to be passed as the
  @racket[#:guard-maker] argument to @racket[make-tuple-implementation]
  or @racket[define-tuple-type]. The guard procedure will ensure that
- the wrapped values are protected by @racket[contract-expr]s.
+ the tuple fields are protected by @racket[contract-expr]s.
  This is analogous to @racket[struct-guard/c].}
 
 @defproc[(tuple-descriptor-type [descriptor tuple-descriptor?]) tuple-type?]{

--- a/type/tuple/descriptor.rkt
+++ b/type/tuple/descriptor.rkt
@@ -212,11 +212,11 @@
   (syntax-parse stx
     #:track-literals
     [(_ contract-expr:expr ...)
-     (define/with-syntax ([ctc arg arg-name arg-index] ...)
+     (define/with-syntax ([ctc arg-sym arg-name-sym field-index] ...)
        (for/list ([ctc (syntax-e #'(contract-expr ...))]
                   [index (in-naturals 1)])
          (list ctc (gensym) (gensym) index)))
-     (define expected-size (length (syntax-e #'(arg ...))))
+     (define expected-size (length (syntax-e #'(contract-expr ...))))
      (quasisyntax/loc stx
        (let ([loc (quote-srcloc #,stx)]
              [blame-party (current-contract-region)])
@@ -225,8 +225,8 @@
            (define constructor-name (tuple-type-constructor-name tuple-type))
            #,(if (= 1 expected-size)
                  #'(begin)
-                 #'(define-values (arg-name ...)
-                     (values (format "~a, field ~a" constructor-name arg-index) ...)))
+                 #'(define-values (arg-name-sym ...)
+                     (values (format "~a, field ~a" constructor-name field-index) ...)))
            (define size (tuple-type-size tuple-type))
            (unless (= size #,expected-size)
              (raise-arguments-error
@@ -234,15 +234,15 @@
               "tuple size mismatch;\n the expected tuple size does not match the given tuple descriptor"
               "expected" #,expected-size
               "given" size))
-           (λ (arg ...)
+           (λ (arg-sym ...)
              #,(if (= 1 expected-size)
-                   #'(contract ctc ... arg ...
+                   #'(contract ctc ... arg-sym ...
                                blame-party blame-party
                                constructor-name loc)
                    #'(values
-                      (contract ctc arg
+                      (contract ctc arg-sym
                                 blame-party blame-party
-                                arg-name loc)
+                                arg-name-sym loc)
                       ...))))))]))
 
 (define (make-tuple-field-accessor descriptor pos)

--- a/type/tuple/descriptor.rkt
+++ b/type/tuple/descriptor.rkt
@@ -3,6 +3,7 @@
 (require racket/contract/base racket/contract/region)
 
 (provide
+ tuple-guard-maker/c
  (contract-out
   [initialized-tuple-descriptor? (-> any/c boolean?)]
   [default-tuple-properties
@@ -38,8 +39,7 @@
          [descriptor initialized-tuple-descriptor?])
         (#:properties [properties impersonator-property-hash/c]
          #:chaperone? [chaperone? boolean?])
-        [_ (descriptor) (tuple-descriptor-predicate descriptor)])])
- tuple-guard-maker/c)
+        [_ (descriptor) (tuple-descriptor-predicate descriptor)])]))
 
 (require racket/math
          racket/struct

--- a/type/tuple/private/definition-macro.rkt
+++ b/type/tuple/private/definition-macro.rkt
@@ -60,7 +60,12 @@
      (~optional
       (~seq #:property-maker property-maker:expr)
       #:defaults ([property-maker #'default-tuple-properties])
-      #:name "#:property-maker option"))
+      #:name "#:property-maker option")
+
+     (~optional
+      (~seq #:guard-maker guard-maker:expr)
+      #:defaults ([guard-maker #'#f])
+      #:name "#:guard-maker option"))
     ...)
   
   #:do [(define size (length (syntax->list #'(field ...))))]
@@ -100,7 +105,8 @@
         #:accessor-name 'accessor
         #:constructor-name 'constructor)
        #:inspector inspector
-       #:property-maker property-maker))
+       #:property-maker property-maker
+       #:guard-maker guard-maker))
     (define constructor (tuple-descriptor-constructor descriptor))
     (define predicate (tuple-descriptor-predicate descriptor))
     (define accessor (tuple-descriptor-accessor descriptor))

--- a/type/wrapper.scrbl
+++ b/type/wrapper.scrbl
@@ -60,12 +60,17 @@ distinguished.
    (code:line #:accessor-name accessor-id)
    (code:line #:pattern-name pattern-id)
    (code:line #:property-maker prop-maker-expr)
+   (code:line #:guard-maker guard-maker-expr)
    (code:line #:inspector inspector-expr)])
 
  #:contracts
  ([prop-maker-expr
    (-> uninitialized-wrapper-descriptor?
        (listof (cons/c struct-type-property? any/c)))]
+  [guard-maker-expr
+   (or/c #f
+         (-> uninitialized-wrapper-descriptor?
+             (-> any/c any/c)))]
   [inspector-expr inspector?])]{
  Creates a new @tech{wrapper type} named @racket[id] and binds the following
  identifiers:
@@ -99,8 +104,9 @@ distinguished.
  bound to, such as when creating a smart constructor.
  
  The @racket[prop-maker-expr] is used to add structure type properties to the
- created type, and @racket[inspector-expr] is used to determine the
- @tech/reference{inspector} that will control the created type. See
+ created type, @racket[inspector-expr] is used to determine the
+ @tech/reference{inspector} that will control the created type, and
+ @racket[guard-maker-expr] is used to create the guard procedure. See
  @racket[make-wrapper-implementation] for more information about these
  parameters.
 
@@ -172,16 +178,39 @@ initialized.
            (-> uninitialized-wrapper-descriptor?
                (listof (cons/c struct-type-property? any/c)))
            default-wrapper-properties]
+          [#:guard-maker guard-maker
+           (or/c #f
+                 (-> uninitialized-wrapper-descriptor?
+                     (-> any/c any/c)))]
           [#:inspector inspector inspector? (current-inspector)])
          initialized-wrapper-descriptor?]{
  Implements @racket[type] and returns a @tech{type descriptor} for the new
- implementation. The @racket[inspector] argument behaves the same as in
+ implementation.
+
+ The @racket[inspector] argument behaves the same as in
  @racket[make-struct-type], although there are no transparent or prefab wrapper
- types. The @racket[prop-maker] argument is similar to the corresponding
- argument of @racket[make-struct-implementation]. By default, wrapper types are
+ types.
+
+ The @racket[prop-maker] argument is similar to the corresponding
+ argument of @racket[make-struct-implementation].
+
+ The @racket[guard-maker] argument is a procedure that should accept the partially
+ constructed wrapper descriptor, and must return a guard procedure. This guard
+ procedure is similar to the one in @racket[make-struct-type]: it will accept
+ the singular argument to the wrapper constructor and the value it returns will be
+ the stored value.
+
+ By default, wrapper types are
  created with properties that make them print and compare in a manner similar to
  transparent structure types --- see @racket[default-wrapper-properties] for
  details.}
+
+@defform[(wrapper-guard-maker/c contract-expr)]{
+ Returns a procedure suitable to be passed as the
+ @racket[#:guard-maker] argument to @racket[make-wrapper-implementation]
+ or @racket[define-wrapper-type]. The guard procedure will ensure that
+ the wrapped value is protected by @racket[contract-expr].
+ This is analogous to @racket[struct-guard/c].}
 
 @defproc[(wrapper-descriptor-type [descriptor wrapper-descriptor?])
          wrapper-type?]{

--- a/type/wrapper.scrbl
+++ b/type/wrapper.scrbl
@@ -102,13 +102,12 @@ distinguished.
  @racket[constructor-id] when used as an expression. Use
  @racket[#:omit-root-binding] when you want control over what @racket[id] is
  bound to, such as when creating a smart constructor.
- 
+
  The @racket[prop-maker-expr] is used to add structure type properties to the
- created type, @racket[inspector-expr] is used to determine the
- @tech/reference{inspector} that will control the created type, and
- @racket[guard-maker-expr] is used to create the guard procedure. See
- @racket[make-wrapper-implementation] for more information about these
- parameters.
+ created type, @racket[guard-maker-expr] is used to create the guard procedure, and
+ @racket[inspector-expr] is used to determine the @tech/reference{inspector} that
+ will control the created type. See @racket[make-wrapper-implementation] for more
+ information about these parameters.
 
  @(examples
    #:eval (make-evaluator) #:once

--- a/type/wrapper/descriptor.rkt
+++ b/type/wrapper/descriptor.rkt
@@ -135,7 +135,7 @@
     (make-tuple-implementation tuple-impl-type
                                #:inspector inspector
                                #:property-maker tuple-impl-prop-maker
-                               #:guard-maker tuple-impl-guard-maker))
+                               #:guard-maker (and guard-maker tuple-impl-guard-maker)))
   (initialized-wrapper-descriptor
    #:type type
    #:predicate (tuple-descriptor-predicate tuple-impl)

--- a/type/wrapper/private/definition-macro.rkt
+++ b/type/wrapper/private/definition-macro.rkt
@@ -59,7 +59,12 @@
      (~optional
       (~seq #:property-maker prop-maker:expr)
       #:defaults ([prop-maker #'default-wrapper-properties])
-      #:name "#:property-maker option"))
+      #:name "#:property-maker option")
+
+     (~optional
+      (~seq #:guard-maker guard-maker:expr)
+      #:name "#:guard-maker option"
+      #:defaults ([guard-maker #'#f])))
     ...)
   
   #:with root-binding
@@ -89,7 +94,8 @@
         #:constructor-name 'constructor
         #:accessor-name 'accessor)
        #:inspector inspector
-       #:property-maker prop-maker))
+       #:property-maker prop-maker
+       #:guard-maker guard-maker))
     (define predicate (wrapper-descriptor-predicate descriptor))
     (define constructor (wrapper-descriptor-constructor descriptor))
     (define accessor (wrapper-descriptor-accessor descriptor))


### PR DESCRIPTION
Adds `#:guard-maker` arguments for tuple, wrapper and record types, as well as `<type>-guard-maker/c` macros for creating these from contracts.

Since these are all implemented in terms of just the tuple type and its guard implementation, and is also somewhat repetitive, I believe it makes most sense to have all of these in a single PR.

Implements #42, and its subtasks: #202, #203, #204.

Supercedes #512. and the same caveat applies for the `<type>-guard-maker/c` macros: they may not be the best for applying contracts, since the calling party is not known to the guard procedure, and thus it has to take any blame for contract violations itself.

