### PR TITLE
Reimplement range sets in terms of sorted maps

### DIFF
--- a/collection/range-set.rkt
+++ b/collection/range-set.rkt
@@ -478,8 +478,8 @@
 
   (test-case (name-string range-subset)
     (define ranges (range-set (singleton-range 1) (closed-range 4 7) (greater-than-range 10)))
-    #;(check-equal? (range-subset ranges (unbounded-range)) ranges)
-#|
+    (check-equal? (range-subset ranges (unbounded-range)) ranges)
+
     (test-case "non-intersecting subset selecting middle ranges only"
       (define subset-range (closed-range 3 8))
       (define expected (range-set (closed-range 4 7)))
@@ -504,7 +504,7 @@
       (define subset-range (less-than-range 6))
       (define expected (range-set (singleton-range 1) (closed-open-range 4 6)))
       (check-equal? (range-subset ranges subset-range) expected))
-|#
+
     (test-case "intersecting subset selecting upper ranges only"
       (define subset-range (greater-than-range 5))
       (define expected (range-set (open-closed-range 5 7) (greater-than-range 10)))

--- a/private/cut.rkt
+++ b/private/cut.rkt
@@ -57,37 +57,46 @@
 
 
 (define (cut<=> base-comparator)
-  (define/guard (cmp left right)
-    (guard (and (equal? left bottom-cut) (equal? right bottom-cut)) then
-      equivalent)
-    (guard (equal? left bottom-cut) then
-      lesser)
-    (guard (equal? right bottom-cut) then
-      greater)
-    (guard (and (equal? left top-cut) (equal? right top-cut)) then
-      equivalent)
-    (guard (equal? left top-cut) then
-      greater)
-    (guard (equal? right top-cut) then
-      lesser)
-    (define result
-      (compare
-       base-comparator
-       (intermediate-cut-value left)
-       (intermediate-cut-value right)))
-    (guard (or (equal? result lesser) (equal? result greater)) then
-      result)
-    (guard (and (lower-cut? left) (lower-cut? right)) then
-      equivalent)
-    (guard (lower-cut? left) then
-      lesser)
-    (guard (lower-cut? right) then
-      greater)
-    (guard (and (middle-cut? left) (middle-cut? right)) then
-      equivalent)
-    (guard (middle-cut? left) then
-      lesser)
-    (guard (middle-cut? right) then
-      greater)
+  ;; Using a cache ensures that a == b implies (cut<=> a) == (cut<=> b)
+  (hash-ref!
+   cut-comparator-cache
+   base-comparator
+   (λ () (make-comparator (cut-compare base-comparator) #:name (name cut<=>)))))
+
+
+(define cut-comparator-cache (make-ephemeron-hash))
+
+
+(define/guard ((cut-compare base-comparator) left right)
+  (guard (and (equal? left bottom-cut) (equal? right bottom-cut)) then
     equivalent)
-  (make-comparator cmp #:name (name cut<=>)))
+  (guard (equal? left bottom-cut) then
+    lesser)
+  (guard (equal? right bottom-cut) then
+    greater)
+  (guard (and (equal? left top-cut) (equal? right top-cut)) then
+    equivalent)
+  (guard (equal? left top-cut) then
+    greater)
+  (guard (equal? right top-cut) then
+    lesser)
+  (define result
+    (compare
+     base-comparator
+     (intermediate-cut-value left)
+     (intermediate-cut-value right)))
+  (guard (or (equal? result lesser) (equal? result greater)) then
+    result)
+  (guard (and (lower-cut? left) (lower-cut? right)) then
+    equivalent)
+  (guard (lower-cut? left) then
+    lesser)
+  (guard (lower-cut? right) then
+    greater)
+  (guard (and (middle-cut? left) (middle-cut? right)) then
+    equivalent)
+  (guard (middle-cut? left) then
+    lesser)
+  (guard (middle-cut? right) then
+    greater)
+  equivalent)


### PR DESCRIPTION
This is a backward-incompatible change since it has to add a comparator argument to some range set construction APIs and that means `into-range-set` is no longer a reducer and is instead a function producing a reducer.