### PR TITLE
Improve range sets

### DIFF
--- a/base/range.rkt
+++ b/base/range.rkt
@@ -163,8 +163,43 @@
 ;; Data model
 
 
-(define-tuple-type range (lower-bound upper-bound comparator)
-  #:omit-root-binding)
+(struct range (lower-bound upper-bound comparator)
+  #:transparent
+  #:constructor-name constructor:range
+  #:omit-define-syntaxes
+
+  #:methods gen:custom-write
+
+  [(define (write-proc this out mode)
+     (define (recur v)
+       (match mode
+         [#true (write v out)]
+         [#false (display v out)]
+         [0 (print v out 0)]
+         [1 (print v out 1)]))
+     (write-string "#<range:" out)
+     (write-string (symbol->string (object-name (range-comparator this))) out)
+     (write-string " " out)
+     (match (range-lower-bound this)
+       [(== unbounded)
+        (write-string "[-∞" out)]
+       [(inclusive-bound lower)
+        (write-string "[" out)
+        (recur lower)]
+       [(exclusive-bound lower)
+        (write-string "(" out)
+        (recur lower)])
+     (write-string ", " out)
+     (match (range-upper-bound this)
+       [(== unbounded)
+        (write-string "∞]" out)]
+       [(inclusive-bound upper)
+        (recur upper)
+        (write-string "]" out)]
+       [(exclusive-bound upper)
+        (recur upper)
+        (write-string ")" out)])
+     (write-string ">" out))])
 
 
 (define-singleton-type unbounded)

--- a/collection/private/endpoint-map-range-set.rkt
+++ b/collection/private/endpoint-map-range-set.rkt
@@ -1,0 +1,472 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ for/range-set
+ for*/range-set
+ (contract-out
+  [range-set (->* () (#:comparator comparator?) #:rest (listof nonempty-range?) immutable-range-set?)]
+  [make-mutable-range-set
+   (->* (#:comparator comparator?) ((sequence/c nonempty-range?)) mutable-range-set?)]
+  [sequence->range-set
+   (-> (sequence/c nonempty-range?) #:comparator comparator? immutable-range-set?)]
+  [into-range-set (-> comparator? (reducer/c nonempty-range? immutable-range-set?))]))
+
+
+(require (for-syntax racket/base
+                     rebellion/private/for-body)
+         (only-in racket/list empty? first)
+         racket/match
+         racket/sequence
+         racket/stream
+         (only-in racket/vector vector-sort)
+         rebellion/base/comparator
+         rebellion/base/option
+         rebellion/base/range
+         (submod rebellion/base/range private-for-rebellion-only)
+         rebellion/collection/entry
+         rebellion/collection/private/range-set-interface
+         (submod rebellion/collection/private/range-set-interface private-for-rebellion-only)
+         rebellion/collection/sorted-map
+         rebellion/collection/vector
+         rebellion/collection/vector/builder
+         rebellion/streaming/reducer
+         (submod rebellion/streaming/reducer private-for-rebellion-only)
+         rebellion/streaming/transducer
+         rebellion/private/cut
+         rebellion/private/guarded-block
+         rebellion/private/precondition
+         rebellion/private/static-name
+         rebellion/private/todo
+         rebellion/private/vector-merge-adjacent
+         syntax/parse/define)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(struct immutable-endpoint-map-range-set abstract-immutable-range-set (endpoints comparator)
+
+  #:omit-define-syntaxes
+
+  #:methods gen:range-set
+
+  [(define (this-endpoints this)
+     (immutable-endpoint-map-range-set-endpoints this))
+
+   (define (this-comparator this)
+     (immutable-endpoint-map-range-set-comparator this))
+
+   (define (in-range-set this #:descending? [descending? #false])
+     (define cmp (this-comparator this))
+     (for/stream ([endpoint-entry (in-sorted-map (this-endpoints this) #:descending? descending?)])
+       (match-define (entry lower upper) endpoint-entry)
+       (range-from-cuts lower upper #:comparator cmp)))
+
+   (define (range-set-comparator this)
+     (this-comparator this))
+
+   (define (range-set-size this)
+     (sorted-map-size (this-endpoints this)))
+
+   (define (range-set-contains? this value)
+     (endpoint-map-contains? (this-endpoints this) (this-comparator this) value))
+
+   (define (range-set-encloses? this range)
+     (endpoint-map-encloses? (this-endpoints this) (this-comparator this) range))
+
+   (define (range-set-intersects? this range)
+     (endpoint-map-intersects? (this-endpoints this) (this-comparator this) range))
+
+   (define (range-set-range-containing-or-absent this value)
+     (endpoint-map-range-containing-or-absent (this-endpoints this) (this-comparator this) value))
+
+   (define (range-set-span-or-absent this)
+     (endpoint-map-span-or-absent (this-endpoints this)))
+
+   (define (range-subset this subset-range)
+     (define cut-comparator (cut<=> (range-comparator subset-range)))
+     (define lower-subset-cut (range-lower-cut subset-range))
+     (define upper-subset-cut (range-upper-cut subset-range))
+     (define subset-endpoint-range
+       (closed-range lower-subset-cut upper-subset-cut #:comparator cut-comparator))
+
+     (define endpoints-submap (sorted-submap (this-endpoints this) subset-endpoint-range))
+
+     (define endpoints-submap-with-left-end-corrected
+       (guarded-block
+        (guard-match (present (entry leftmost-range-lower-cut leftmost-range-upper-cut))
+          (sorted-map-entry-at-most (this-endpoints this) lower-subset-cut)
+          else
+          endpoints-submap)
+        (guard (compare-infix cut-comparator leftmost-range-upper-cut > lower-subset-cut) else
+          endpoints-submap)
+        (define corrected-lower-range
+          (range-from-cuts lower-subset-cut leftmost-range-upper-cut #:comparator cut-comparator))
+        (guard (empty-range? corrected-lower-range) then
+          endpoints-submap)
+        (sorted-map-put endpoints-submap lower-subset-cut leftmost-range-upper-cut)))
+
+     (define endpoints-submap-with-right-end-corrected
+       (guarded-block
+        (guard-match (present (entry rightmost-range-lower-cut rightmost-range-upper-cut))
+          (sorted-map-greatest-entry endpoints-submap-with-left-end-corrected)
+          else
+          endpoints-submap-with-left-end-corrected)
+        (define corrected-upper-cut
+          (comparator-min cut-comparator rightmost-range-upper-cut upper-subset-cut))
+        (define corrected-rightmost-range
+          (range-from-cuts rightmost-range-lower-cut corrected-upper-cut #:comparator cut-comparator))
+        (guard (empty-range? corrected-rightmost-range) then
+          (sorted-map-remove endpoints-submap-with-left-end-corrected rightmost-range-lower-cut))
+        (sorted-map-put
+         endpoints-submap-with-left-end-corrected rightmost-range-lower-cut corrected-upper-cut)))
+
+     (immutable-endpoint-map-range-set
+      endpoints-submap-with-right-end-corrected (this-comparator this)))]
+
+  #:methods gen:immutable-range-set
+
+  [(define (this-endpoints this)
+     (immutable-endpoint-map-range-set-endpoints this))
+
+   (define (this-comparator this)
+     (immutable-endpoint-map-range-set-comparator this))
+
+   (define/guard (range-set-add this range)
+     (define cmp (this-comparator this))
+     (check-precondition
+      (equal? cmp (range-comparator range))
+      (name range-set-add)
+      "added range does not use the same comparator as the range set"
+      "range" range
+      "range comparator" (range-comparator range)
+      "range set comparator" cmp)
+     (guard (empty-range? range) then
+       this)
+     (define endpoints (this-endpoints this))
+     (define cut-cmp (sorted-map-key-comparator endpoints))
+     (define lower-endpoint-cut (range-lower-cut range))
+     (define upper-endpoint-cut (range-upper-cut range))
+     (define left-overlapping-range (sorted-map-entry-at-most endpoints lower-endpoint-cut))
+     (define right-overlapping-range
+       (sorted-map-entry-at-most
+        (sorted-submap endpoints (at-least-range lower-endpoint-cut #:comparator cut-cmp))
+        upper-endpoint-cut))
+
+     (define new-lower-endpoint
+       (match left-overlapping-range
+         [(present (entry left-overlapping-lower-endpoint left-overlapping-upper-endpoint))
+          (if (compare-infix cut-cmp left-overlapping-upper-endpoint >= lower-endpoint-cut)
+              (comparator-min cut-cmp lower-endpoint-cut left-overlapping-lower-endpoint)
+              lower-endpoint-cut)]
+         [(== absent) lower-endpoint-cut]))
+  
+     (define new-upper-endpoint
+       (match right-overlapping-range
+         [(present (entry _ right-overlapping-upper-endpoint))
+          (comparator-max cut-cmp upper-endpoint-cut right-overlapping-upper-endpoint)]
+         [(== absent) upper-endpoint-cut]))
+
+     (define range-to-remove
+       (closed-range new-lower-endpoint new-upper-endpoint #:comparator cut-cmp))
+     (define endpoints-to-remove (sorted-map-keys (sorted-submap endpoints range-to-remove)))
+     (define new-endpoints
+       (sorted-map-put (sorted-map-remove-all endpoints endpoints-to-remove)
+                       new-lower-endpoint new-upper-endpoint))
+     (immutable-endpoint-map-range-set new-endpoints cmp))
+
+   (define/guard (range-set-remove this range)
+     (define cmp (this-comparator this))
+     (check-precondition
+      (equal? cmp (range-comparator range))
+      (name range-set-remove)
+      "removed range does not use the same comparator as the range set"
+      "range" range
+      "range comparator" (range-comparator range)
+      "range set comparator" cmp)
+     (guard (empty-range? range) then
+       this)
+     (define endpoints (this-endpoints this))
+     (define cut-cmp (sorted-map-key-comparator endpoints))
+     (define lower-endpoint (range-lower-cut range))
+     (define upper-endpoint (range-upper-cut range))
+     (define left-overlapping-range (sorted-map-entry-at-most endpoints lower-endpoint))
+     (define right-overlapping-range (sorted-map-entry-at-most endpoints upper-endpoint))
+
+     (define lowest-endpoint
+       (match left-overlapping-range
+         [(present (entry left-overlapping-lower-endpoint left-overlapping-upper-endpoint))
+          (if (compare-infix cut-cmp left-overlapping-upper-endpoint >= lower-endpoint)
+              (comparator-min cut-cmp lower-endpoint left-overlapping-lower-endpoint)
+              lower-endpoint)]
+         [(== absent) lower-endpoint]))
+
+     (define new-left-overlapping-endpoints
+       (match left-overlapping-range
+         [(present (entry left-overlapping-lower-endpoint left-overlapping-upper-endpoint))
+          (present
+           (entry
+            left-overlapping-lower-endpoint
+            (comparator-min cut-cmp left-overlapping-upper-endpoint lower-endpoint)))]
+         [(== absent) absent]))
+  
+     (define highest-endpoint
+       (match right-overlapping-range
+         [(present (entry _ right-overlapping-upper-endpoint))
+          (comparator-max cut-cmp upper-endpoint right-overlapping-upper-endpoint)]
+         [(== absent) upper-endpoint]))
+
+     (define new-right-overlapping-endpoints
+       (match right-overlapping-range
+         [(present (entry right-overlapping-lower-endpoint right-overlapping-upper-endpoint))
+          (if (compare-infix cut-cmp upper-endpoint < right-overlapping-upper-endpoint)
+              (present
+               (entry
+                (comparator-max cut-cmp right-overlapping-lower-endpoint upper-endpoint)
+                right-overlapping-upper-endpoint))
+              absent)]
+         [(== absent) absent]))
+
+     (define range-to-remove
+       (closed-range lowest-endpoint highest-endpoint #:comparator cut-cmp))
+     (define endpoints-to-remove (sorted-map-keys (sorted-submap endpoints range-to-remove)))
+     (let* ([new-endpoints (sorted-map-remove-all endpoints endpoints-to-remove)]
+            [new-endpoints
+             (match new-left-overlapping-endpoints
+               [(present (entry new-left-lower new-left-upper))
+                #:when (not (equal? new-left-lower new-left-upper))
+                (sorted-map-put new-endpoints new-left-lower new-left-upper)]
+               [_ new-endpoints])]
+            [new-endpoints
+             (match new-right-overlapping-endpoints
+               [(present (entry new-right-lower new-right-upper))
+                #:when (not (equal? new-right-lower new-right-upper))
+                (sorted-map-put new-endpoints new-right-lower new-right-upper)]
+               [_ new-endpoints])])
+       (immutable-endpoint-map-range-set new-endpoints cmp)))])
+
+
+(struct mutable-endpoint-map-range-set abstract-mutable-range-set (endpoints comparator)
+
+  #:omit-define-syntaxes
+
+  #:methods gen:range-set
+
+  [(define (this-endpoints this)
+     (mutable-endpoint-map-range-set-endpoints this))
+
+   (define (this-comparator this)
+     (mutable-endpoint-map-range-set-comparator this))
+
+   (define (in-range-set this #:descending? [descending? #false])
+     (define cmp (this-comparator this))
+     (for/stream ([endpoint-entry (in-sorted-map (this-endpoints this) #:descending? descending?)])
+       (match-define (entry lower upper) endpoint-entry)
+       (range-from-cuts lower upper #:comparator cmp)))
+
+   (define (range-set-comparator this)
+     (this-comparator this))
+
+   (define (range-set-size this)
+     (sorted-map-size (this-endpoints this)))
+
+   (define (range-set-contains? this value)
+     (endpoint-map-contains? (this-endpoints this) (this-comparator this) value))
+
+   (define (range-set-encloses? this range)
+     (endpoint-map-encloses? (this-endpoints this) (this-comparator this) range))
+
+   (define (range-set-intersects? this range)
+     (endpoint-map-intersects? (this-endpoints this) (this-comparator this) range))
+
+   (define (range-set-range-containing-or-absent this value)
+     (endpoint-map-range-containing-or-absent (this-endpoints this) (this-comparator this) value))
+
+   (define (range-set-span-or-absent this)
+     (endpoint-map-span-or-absent (this-endpoints this)))
+
+   (define (range-subset this subset-range)
+     TODO)]
+
+  #:methods gen:mutable-range-set
+
+  [(define (this-endpoints this)
+     (immutable-endpoint-map-range-set-endpoints this))
+
+   (define (this-comparator this)
+     (immutable-endpoint-map-range-set-comparator this))
+
+   (define/guard (range-set-add! this range)
+     (define cmp (this-comparator this))
+     (check-precondition
+      (equal? cmp (range-comparator range))
+      (name range-set-add)
+      "added range does not use the same comparator as the range set"
+      "range" range
+      "range comparator" (range-comparator range)
+      "range set comparator" cmp)
+     (guard (empty-range? range) then
+       (void))
+     TODO)
+
+   (define/guard (range-set-remove! this range)
+     (define cmp (this-comparator this))
+     (check-precondition
+      (equal? cmp (range-comparator range))
+      (name range-set-remove)
+      "removed range does not use the same comparator as the range set"
+      "range" range
+      "range comparator" (range-comparator range)
+      "range set comparator" cmp)
+     (guard (empty-range? range) then
+       (void))
+     TODO)
+
+   (define (range-set-clear! this)
+     (sorted-map-clear! (this-endpoints this)))])
+
+
+(define (make-mutable-range-set [initial-ranges '()] #:comparator comparator)
+  (define ranges (sequence->vector initial-ranges))
+  (check-ranges-use-comparator #:who (name make-mutable-range-set) ranges comparator)
+  (define sorted-ranges (vector-sort ranges range<?))
+  (check-ranges-disjoint #:who (name make-mutable-range-set) sorted-ranges)
+  (define coalesced-ranges (vector-merge-adjacent sorted-ranges range-connected? range-span))
+  (define endpoints (make-mutable-sorted-map #:key-comparator (cut<=> comparator)))
+  (for ([range (in-vector coalesced-ranges)])
+    (sorted-map-put! endpoints (range-lower-cut range) (range-upper-cut range)))
+  (mutable-endpoint-map-range-set endpoints comparator))
+
+
+(define (endpoint-map-contains? endpoints comparator value)
+  (match (endpoint-map-get-nearest-range endpoints comparator (middle-cut value))
+    [(== absent) #false]
+    [(present nearest-range) (range-contains? nearest-range value)]))
+
+
+(define (endpoint-map-encloses? endpoints comparator range)
+  (match (endpoint-map-get-nearest-range endpoints comparator (range-lower-cut range))
+    [(== absent) #false]
+    [(present nearest-range) (range-encloses? nearest-range range)]))
+
+
+(define/guard (endpoint-map-intersects? endpoints comparator range)
+  (define lower-cut (range-lower-cut range))
+  (define upper-cut (range-upper-cut range))
+  (guard-match (present (entry _ upper)) (sorted-map-entry-at-most endpoints upper-cut) else
+    #false)
+  (compare-infix (cut<=> (range-comparator range)) lower-cut < upper))
+    
+
+
+(define (endpoint-map-range-containing-or-absent endpoints comparator value)
+  (option-filter
+   (endpoint-map-get-nearest-range endpoints comparator (middle-cut value))
+   (λ (nearest-range) (range-contains? nearest-range value))))
+
+
+(define (endpoint-map-span-or-absent endpoints)
+  TODO)
+
+
+(define/guard (endpoint-map-get-nearest-range endpoints comparator cut)
+  (guard-match (present (entry lower upper)) (sorted-map-entry-at-most endpoints cut) else
+    absent)
+  (present (range-from-cuts lower upper #:comparator comparator)))
+
+
+;@----------------------------------------------------------------------------------------------------
+;; Construction APIs
+
+
+(define (range-set #:comparator [comparator #false] . ranges)
+  (check-precondition
+   (or comparator (not (empty? ranges)))
+   (name range-set)
+   "cannot construct an empty range set without a comparator")
+  (let ([comparator (or comparator (range-comparator (first ranges)))])
+    (sequence->range-set ranges #:comparator comparator)))
+
+
+(define (sequence->range-set ranges #:comparator comparator)
+  (transduce ranges #:into (into-range-set comparator)))
+
+
+(struct range-set-builder ([range-vector-builder #:mutable] comparator))
+
+
+(define (make-range-set-builder comparator)
+  (range-set-builder (make-vector-builder) comparator))
+
+
+(define (range-set-builder-add builder range)
+  (define vector-builder (vector-builder-add (range-set-builder-range-vector-builder builder) range))
+  (set-range-set-builder-range-vector-builder! builder vector-builder)
+  builder)
+
+
+(define (build-range-set builder)
+  (define ranges (build-vector (range-set-builder-range-vector-builder builder)))
+  (define comparator (range-set-builder-comparator builder))
+  (check-ranges-use-comparator #:who (name build-range-set) ranges comparator)
+  (define sorted-ranges (vector-sort ranges range<?))
+  (check-ranges-disjoint #:who (name build-range-set) sorted-ranges)
+  (define coalesced-ranges (vector-merge-adjacent sorted-ranges range-connected? range-span))
+  (define endpoints
+    (for/sorted-map #:key-comparator (cut<=> comparator) ([range (in-vector coalesced-ranges)])
+      (entry (range-lower-cut range) (range-upper-cut range))))
+  (immutable-endpoint-map-range-set endpoints comparator))
+
+
+(define (check-ranges-use-comparator #:who who ranges comparator)
+  (for ([range (in-vector ranges)])
+    (check-precondition
+     (equal? (range-comparator range) comparator)
+     who
+     "not all ranges use the same comparator"
+     "range" range
+     "range comparator" (range-comparator range)
+     "expected comparator" comparator)))
+
+
+(define (range<? range other-range)
+  (equal? (compare range<=> range other-range) lesser))
+
+
+(define (check-ranges-disjoint #:who who ranges)
+  (unless (zero? (vector-length ranges))
+    (for ([range (in-vector ranges)]
+          [next-range (in-vector ranges 1)])
+      (when (range-overlaps? range next-range)
+        (raise-arguments-error
+         who
+         "overlapping ranges not allowed"
+         "range" range
+         "next range" next-range)))))
+
+
+(define (into-range-set comparator)
+
+  (define (start)
+    (make-range-set-builder comparator))
+  
+  (make-effectful-fold-reducer
+   range-set-builder-add start build-range-set #:name (name into-range-set)))
+
+
+(define-syntax-parse-rule (for/range-set #:comparator comparator clauses body)
+  #:declare comparator (expr/c #'comparator?)
+  #:declare body (for-body this-syntax)
+  #:with context this-syntax
+  (for/reducer/derived context (into-range-set comparator.c) clauses (~@ . body)))
+
+
+(define-syntax-parse-rule (for*/range-set #:comparator comparator clauses body)
+  #:declare comparator (expr/c #'comparator?)
+  #:declare body (for-body this-syntax)
+  #:with context this-syntax
+  (for*/reducer/derived context (into-range-set comparator.c) clauses (~@ . body)))

--- a/collection/private/range-set-interface.rkt
+++ b/collection/private/range-set-interface.rkt
@@ -1,0 +1,251 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [range-set? predicate/c]
+  [immutable-range-set? predicate/c]
+  [mutable-range-set? predicate/c]
+  [in-range-set (->* (range-set?) (#:descending? boolean?) (sequence/c nonempty-range?))]
+  [range-set-comparator (-> range-set? comparator?)]
+  [range-set-empty? (-> range-set? boolean?)]
+  [range-set-size (-> range-set? exact-nonnegative-integer?)]
+  [range-set-contains? (-> range-set? any/c boolean?)]
+  [range-set-contains-all? (-> range-set? (sequence/c any/c) boolean?)]
+  [range-set-encloses? (-> range-set? range? boolean?)]
+  [range-set-encloses-all? (-> range-set? (sequence/c range?) boolean?)]
+  [range-set-intersects? (-> range-set? range? boolean?)]
+  [range-set-range-containing (->* (range-set? any/c) (failure-result/c) any)]
+  [range-set-range-containing-or-absent (-> range-set? any/c (option/c range?))]
+  [range-set-span (->* (range-set?) (failure-result/c) any)]
+  [range-set-span-or-absent (-> range-set? (option/c range?))]
+  [range-set-add (-> immutable-range-set? range? immutable-range-set?)]
+  [range-set-add! (-> mutable-range-set? range? void?)]
+  [range-set-add-all (-> immutable-range-set? (sequence/c range?) immutable-range-set?)]
+  [range-set-add-all! (-> mutable-range-set? (sequence/c range?) void?)]
+  [range-set-remove (-> immutable-range-set? range? immutable-range-set?)]
+  [range-set-remove! (-> mutable-range-set? range? void?)]
+  [range-set-remove-all (-> immutable-range-set? (sequence/c range?) immutable-range-set?)]
+  [range-set-remove-all! (-> mutable-range-set? (sequence/c range?) void?)]
+  [range-set-clear! (-> mutable-range-set? void?)]
+  [range-subset (-> range-set? range? range-set?)]))
+
+
+;; The APIs for creating the generic, extensible hierarchy of collection implementations exist only to
+;; make it easier to organize Rebellion's various implementations. They are *not* designed for
+;; external consumption, and no promises of API stability or quality are made. Please do not make your
+;; own implementations of these interfaces; instead file an issue at
+;; https://github.com/jackfirth/rebellion/issues describing your use case. These APIs might be made
+;; public in the future, depending on feedback from users.
+(module+ private-for-rebellion-only
+  (provide
+   (struct-out abstract-range-set)
+   (struct-out abstract-mutable-range-set)
+   (struct-out abstract-immutable-range-set)
+   gen:range-set
+   gen:mutable-range-set
+   gen:immutable-range-set
+   (contract-out
+    [default-range-set-value-not-contained-failure-result (-> any/c range-set? failure-result/c)]
+    [default-empty-range-set-span-failure-result failure-result/c])))
+
+
+(require racket/generic
+         racket/match
+         racket/sequence
+         racket/unsafe/ops
+         rebellion/base/comparator
+         rebellion/base/option
+         rebellion/base/range
+         rebellion/private/guarded-block
+         rebellion/private/printer-markup
+         rebellion/private/static-name)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+;; This is the API for *unmodifiable* range sets. Unmodifiable range sets do not expose an API for
+;; clients to mutate them, but they make no guarantees that they will not mutate of their own accord.
+;; For example, one module may wish to provide an *unmodifiable view* of a mutable range set to
+;; clients to prevent uncontrolled external mutation. Such a view is unmodifiable, but not immutable,
+;; as the underlying map backing the view may mutate.
+(define-generics range-set
+
+  ;; descending? should always default to false
+  (in-range-set range-set #:descending? [descending?])
+
+  (range-set-comparator range-set)
+  (range-set-empty? range-set)
+  (range-set-size range-set)
+  (range-set-contains? range-set value)
+  (range-set-contains-all? range-set values)
+  (range-set-encloses? range-set range)
+  (range-set-encloses-all? range-set ranges)
+  (range-set-intersects? range-set range)
+  (range-set-range-containing range-set value [failure-result])
+  (range-set-range-containing-or-absent range-set value)
+  (range-set-span range-set [failure-result])
+  (range-set-span-or-absent range-set)
+  (range-subset range-set subrange)
+
+  #:fallbacks
+
+  [(define/generic generic-size range-set-size)
+   (define/generic generic-contains? range-set-contains?)
+   (define/generic generic-encloses? range-set-encloses?)
+   (define/generic generic-range-containing-or-absent range-set-range-containing-or-absent)
+   (define/generic generic-span-or-absent range-set-span-or-absent)
+   
+   (define (range-set-empty? this)
+     (zero? (generic-size this)))
+
+   (define (range-set-contains-all? this values)
+     (for/and ([value values])
+       (generic-contains? this value)))
+
+   (define (range-set-encloses-all? this ranges)
+     (for/and ([range ranges])
+       (generic-encloses? this range)))
+
+   (define
+     (range-set-range-containing
+      this
+      value
+      [failure-result (default-range-set-value-not-contained-failure-result this value)])
+     (match (generic-range-containing-or-absent this value)
+       [(present range) range]
+       [(== absent) (if (procedure? failure-result) (failure-result) failure-result)]))
+
+   (define (range-set-span this [failure-result default-empty-range-set-span-failure-result])
+     (match (generic-span-or-absent this)
+       [(present span) span]
+       [(== absent) (if (procedure? failure-result) (failure-result) failure-result)]))])
+
+
+(define ((default-range-set-value-not-contained-failure-result range-set value))
+  (define message
+    (format "~a: no range containing value;\n  ranges: ~e  value: ~e\n"
+            (name range-set-range-containing) range-set value))
+  (raise (make-exn:fail:contract message (current-continuation-marks))))
+
+
+(define (default-empty-range-set-span-failure-result)
+  (define message
+    (format "~a: range set is empty and has no span" (name range-set-span)))
+  (raise (make-exn:fail:contract message (current-continuation-marks))))
+
+
+;; Subtypes must implement the gen:range-set interface.
+(struct abstract-range-set ()
+
+  #:property prop:sequence in-range-set
+
+  #:methods gen:custom-write
+
+  [(define write-proc (make-constructor-style-printer-with-markup 'range-set in-range-set))])
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define-generics immutable-range-set
+
+  (range-set-add immutable-range-set range)
+  (range-set-add-all immutable-range-set ranges)
+  (range-set-remove immutable-range-set range)
+  (range-set-remove-all immutable-range-set ranges)
+
+  #:fallbacks
+
+  [(define/generic generic-add range-set-add)
+   (define/generic generic-remove range-set-remove)
+
+   (define (range-set-add-all this ranges)
+     (for/fold ([this this])
+               ([range ranges])
+       (generic-add this range)))
+
+   (define (range-set-remove-all this ranges)
+     (for/fold ([this this])
+               ([range ranges])
+       (generic-remove this range)))])
+
+
+;; Subtypes must implement the gen:range-set interface *and* the gen:immutable-range-set interface.
+(struct abstract-immutable-range-set abstract-range-set ()
+
+  #:methods gen:custom-write
+
+  [(define write-proc
+     (make-constructor-style-printer-with-markup 'immutable-range-set in-range-set))]
+
+  ;; Immutable range sets are always compared structurally. Two immutable range sets are equal if
+  ;; they use equal comparators and they contain the same ranges.
+  #:methods gen:equal+hash
+
+  [(define/guard (equal-proc this other recur)
+
+     (guard (recur (range-set-comparator this) (range-set-comparator other)) else
+       #false)
+
+     ;; We check emptiness as a fast path, since empty collections are common in practice and
+     ;; easy to optimize for.
+     (guard (range-set-empty? this) then
+       (range-set-empty? other))
+     (guard (range-set-empty? other) then
+       #false)
+
+     ;; We check the size before comparing elements so that we can avoid paying the O(n) range
+     ;; comparison cost most of the time.
+     (and (recur (range-set-size this) (range-set-size other))
+          (for/and ([this-range (in-range-set this)]
+                    [other-range (in-range-set other)])
+            (recur this-range other-range))))
+
+   (define (hash-proc this recur)
+     (for/fold ([hash-code (recur (range-set-comparator this))])
+               ([range (in-range-set this)])
+       (unsafe-fx+/wraparound hash-code (recur range))))
+
+   (define hash2-proc hash-proc)])
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define-generics mutable-range-set
+
+  (range-set-add! mutable-range-set range)
+  (range-set-add-all! mutable-range-set ranges)
+  (range-set-remove! mutable-range-set range)
+  (range-set-remove-all! mutable-range-set ranges)
+  (range-set-clear! mutable-range-set)
+
+  #:fallbacks
+
+  [(define/generic generic-add! range-set-add!)
+   (define/generic generic-remove! range-set-remove!)
+
+   (define (range-set-add-all! this ranges)
+     (for ([range ranges])
+       (generic-add! this range)))
+
+   (define (range-set-remove-all! this ranges)
+     (for ([range ranges])
+       (generic-remove! this range)))])
+
+
+;; Subtypes must implement the gen:range-set interface *and* the gen:mutable-range-set interface.
+;; Mutable range sets don't implement gen:equal+hash because two mutable objects should only be equal
+;; if they have the same identity: that is, if mutations to one are reflected by the other. This does
+;; not necessarily mean only eq? mutable objects should be equal?, as it's perfectly fine for a
+;; wrapper or view of a mutable object to be equal? to that object.
+(struct abstract-mutable-range-set abstract-range-set ()
+
+  #:methods gen:custom-write
+
+  [(define write-proc (make-constructor-style-printer-with-markup 'mutable-range-set in-range-set))])

--- a/collection/range-set.rkt
+++ b/collection/range-set.rkt
@@ -1,265 +1,75 @@
 #lang racket/base
 
 
-(require racket/contract/base)
+(require racket/contract/base
+         rebellion/collection/private/endpoint-map-range-set
+         rebellion/collection/private/range-set-interface)
 
 
 (provide
  for/range-set
  for*/range-set
+ (recontract-out
+  range-set?
+  immutable-range-set?
+  mutable-range-set?
+  range-set
+  make-mutable-range-set
+  sequence->range-set
+  into-range-set
+  in-range-set
+  range-set-comparator
+  range-set-empty?
+  range-set-size
+  range-set-contains?
+  range-set-contains-all?
+  range-set-encloses?
+  range-set-encloses-all?
+  range-set-intersects?
+  range-set-range-containing
+  range-set-range-containing-or-absent
+  range-set-span
+  range-set-span-or-absent
+  range-set-add
+  range-set-add!
+  range-set-add-all
+  range-set-add-all!
+  range-set-remove
+  range-set-remove!
+  range-set-remove-all
+  range-set-remove-all!
+  range-set-clear!
+  range-subset)
  (contract-out
-  [range-set? predicate/c]
-  [range-set (->* () (#:comparator comparator?) #:rest (listof nonempty-range?) range-set?)]
-  [range-set-size (-> range-set? natural?)]
-  [range-set-comparator (-> range-set? comparator?)]
-  [sequence->range-set (-> (sequence/c nonempty-range?) #:comparator comparator? range-set?)]
-  [into-range-set (-> comparator? (reducer/c nonempty-range? range-set?))]
-  [in-range-set (-> range-set? (sequence/c nonempty-range?))]
   [empty-range-set? predicate/c]
-  [nonempty-range-set? predicate/c]
-  [range-set-contains? (-> range-set? any/c boolean?)]
-  [range-set-encloses? (-> range-set? range? boolean?)]
-  [range-set-encloses-all? (-> range-set? (or/c range-set? (sequence/c range?)) boolean?)]
-  [range-subset (-> range-set? range? range-set?)]))
-
-
-(require (for-syntax racket/base
-                     rebellion/private/for-body)
-         (only-in racket/list empty? first)
-         racket/match
-         racket/math
-         racket/sequence
-         racket/stream
-         racket/struct
-         (only-in racket/unsafe/ops unsafe-vector*->immutable-vector!)
-         racket/vector
-         rebellion/base/comparator
-         rebellion/base/option
-         rebellion/base/range
-         (submod rebellion/base/range private-for-rebellion-only)
-         rebellion/collection/entry
-         rebellion/collection/private/vector-binary-search
-         rebellion/collection/sorted-map
-         rebellion/collection/vector/builder
-         rebellion/private/cut
-         rebellion/private/guarded-block
-         rebellion/private/precondition
-         rebellion/private/static-name
-         rebellion/streaming/reducer
-         (submod rebellion/streaming/reducer private-for-rebellion-only)
-         rebellion/streaming/transducer
-         rebellion/type/tuple
-         syntax/parse/define)
+  [nonempty-range-set? predicate/c]))
 
 
 (module+ test
   (require (submod "..")
-           rackunit))
-
-
-;@----------------------------------------------------------------------------------------------------
-;; Vector utilities
-
-
-;; Vector A, BiPredicate A, BinaryOperator A -> ImmutableVector A
-;; Returns a new vector that is like vec, except adjacent elements are merged with merge-function when
-;; should-merge? returns true.
-;; Examples:
-;; > (vector-merge-adjacent (vector 1 2 3 "hello" 4 5 "world" 6) both-numbers? +)
-;; (vector 6 "hello" 9 "world" 6)
-(define/guard (vector-merge-adjacent vec should-merge? merge-function)
-  (define count (vector-length vec))
-  (guard (< count 2) then
-    (vector->immutable-vector vec))
-  (for/fold ([builder (make-vector-builder #:expected-size count)]
-             [element (vector-ref vec 0)]
-             #:result (build-vector (vector-builder-add builder element)))
-            ([next-element (in-vector vec 1)])
-    (if (should-merge? element next-element)
-        (values builder (merge-function element next-element))
-        (values (vector-builder-add builder element) next-element))))
-
-
-(module+ test
-  (test-case (name-string vector-merge-adjacent)
-
-    (define (both-numbers? left right)
-      (and (number? left) (number? right)))
-
-    (define (fail-immediately left right)
-      (raise 'should-not-be-called))
-
-    (test-case "empty vectors are returned uninspected"
-      (define actual (vector-merge-adjacent (vector-immutable) fail-immediately fail-immediately))
-      (check-equal? actual (vector-immutable)))
-
-    (test-case "single-element vectors are returned uninspected"
-      (define actual (vector-merge-adjacent (vector-immutable 1) fail-immediately fail-immediately))
-      (check-equal? actual (vector-immutable 1)))
-
-    (test-case "can merge all elements"
-      (define actual (vector-merge-adjacent (vector-immutable 1 2 3 4 5) (λ (a b) #true) +))
-      (check-equal? actual (vector-immutable 15)))
-
-    (test-case "can merge no elements"
-      (define actual
-        (vector-merge-adjacent (vector-immutable 1 2 3 4 5) (λ (a b) #false) fail-immediately))
-      (check-equal? actual (vector-immutable 1 2 3 4 5)))
-
-    (test-case "can merge elements at start"
-      (define actual (vector-merge-adjacent (vector-immutable 1 2 3 'a 'b 'c) both-numbers? +))
-      (check-equal? actual (vector-immutable 6 'a 'b 'c)))
-
-    (test-case "can merge elements at end"
-      (define actual (vector-merge-adjacent (vector-immutable 'a 'b 'c 4 5 6) both-numbers? +))
-      (check-equal? actual (vector-immutable 'a 'b 'c 15)))
-
-    (test-case "can merge elements in middle"
-      (define actual
-        (vector-merge-adjacent (vector-immutable 'a 'b 'c 4 5 6 'd 'e 'f) both-numbers? +))
-      (check-equal? actual (vector-immutable 'a 'b 'c 15 'd 'e 'f)))
-
-    (test-case "can merge elements in middle multiple times"
-      (define actual
-        (vector-merge-adjacent (vector-immutable 1 2 3 "hello" 4 5 "world" 6) both-numbers? +))
-      (check-equal? actual (vector-immutable 6 "hello" 9 "world" 6)))))
+           racket/sequence
+           rackunit
+           rebellion/base/comparator
+           rebellion/base/range
+           rebellion/private/static-name
+           rebellion/private/todo
+           rebellion/streaming/transducer))
 
 
 ;@----------------------------------------------------------------------------------------------------
 ;; Data definition
 
-
-(struct range-set (endpoints comparator)
-  #:omit-define-syntaxes
-  #:constructor-name constructor:range-set
-
-  #:property prop:sequence (λ (this) (in-range-set this))
-
-  #:methods gen:custom-write
-
-  [(define write-proc
-     (make-constructor-style-printer
-      (λ (this) 'range-set)
-      (λ (this) this)))]
-
-  #:methods gen:equal+hash
-
-  [(define (equal-proc this other recur)
-     (recur (range-set-endpoints this) (range-set-endpoints other)))
-
-   (define (hash-proc this recur)
-     (recur (range-set-endpoints this)))
-
-   (define hash2-proc hash-proc)])
-
-
-(define (range-set #:comparator [comparator #false] . ranges)
-  (check-precondition
-   (or comparator (not (empty? ranges)))
-   (name range-set)
-   "cannot construct an empty range set without a comparator")
-  (let ([comparator (or comparator (range-comparator (first ranges)))])
-    (sequence->range-set ranges #:comparator comparator)))
-
-
-(define (sequence->range-set ranges #:comparator comparator)
-  (transduce ranges #:into (into-range-set comparator)))
-
-
 (define (empty-range-set? v)
-  (and (range-set? v) (sorted-map-empty? (range-set-endpoints v))))
+  (and (range-set? v) (range-set-empty? v)))
 
 
 (define (nonempty-range-set? v)
-  (and (range-set? v) (not (sorted-map-empty? (range-set-endpoints v)))))
-
-
-(define (in-range-set ranges)
-  (define comparator (range-set-comparator ranges))
-  (for/stream ([e (in-sorted-map (range-set-endpoints ranges))])
-    (match-define (entry lower upper) e)
-    (range-from-cuts lower upper #:comparator comparator)))
-
-
-(struct range-set-builder ([range-vector-builder #:mutable] comparator))
-
-
-(define (make-range-set-builder comparator)
-  (range-set-builder (make-vector-builder) comparator))
-
-
-(define (range-set-builder-add-range builder range)
-  (define vector-builder (vector-builder-add (range-set-builder-range-vector-builder builder) range))
-  (set-range-set-builder-range-vector-builder! builder vector-builder)
-  builder)
-
-
-(define (build-range-set builder)
-  (define ranges (build-vector (range-set-builder-range-vector-builder builder)))
-  (define comparator (range-set-builder-comparator builder))
-  (check-ranges-use-comparator #:who (name build-range-set) ranges comparator)
-  (define sorted-ranges (vector-sort ranges range<?))
-  (check-ranges-disjoint #:who (name build-range-set) sorted-ranges)
-  (define coalesced-ranges (vector-merge-adjacent sorted-ranges range-connected? range-span))
-  (define endpoints
-    (for/sorted-map #:key-comparator (cut<=> comparator) ([range (in-vector coalesced-ranges)])
-      (entry (range-lower-cut range) (range-upper-cut range))))
-  (constructor:range-set endpoints comparator))
-
-
-(define (check-ranges-use-comparator #:who who ranges comparator)
-  (for ([range (in-vector ranges)])
-    (check-precondition
-     (equal? (range-comparator range) comparator)
-     who
-     "not all ranges use the same comparator"
-     "range" range
-     "range comparator" (range-comparator range)
-     "expected comparator" comparator)))
-
-
-(define (range<? range other-range)
-  (equal? (compare range<=> range other-range) lesser))
-
-
-(define (check-ranges-disjoint #:who who ranges)
-  (unless (zero? (vector-length ranges))
-    (for ([range (in-vector ranges)]
-          [next-range (in-vector ranges 1)])
-      (when (range-overlaps? range next-range)
-        (raise-arguments-error
-         who
-         "overlapping ranges not allowed"
-         "range" range
-         "next range" next-range)))))
-
-
-(define (into-range-set comparator)
-
-  (define (start)
-    (make-range-set-builder comparator))
-  
-  (make-effectful-fold-reducer
-   range-set-builder-add-range start build-range-set #:name (name into-range-set)))
-
-
-(define-syntax-parse-rule (for/range-set #:comparator comparator clauses body)
-  #:declare comparator (expr/c #'comparator?)
-  #:declare body (for-body this-syntax)
-  #:with context this-syntax
-  (for/reducer/derived context (into-range-set comparator.c) clauses (~@ . body)))
-
-
-(define-syntax-parse-rule (for*/range-set #:comparator comparator clauses body)
-  #:declare comparator (expr/c #'comparator?)
-  #:declare body (for-body this-syntax)
-  #:with context this-syntax
-  (for*/reducer/derived context (into-range-set comparator.c) clauses (~@ . body)))
+  (and (range-set? v) (not (range-set-empty? v))))
 
 
 (module+ test
 
-  (test-case "range sets"
+  (test-case "range set construction"
 
     (test-case "single range"
       (define actual (range-set (closed-range 1 4)))
@@ -326,107 +136,77 @@
         (define expected-equivalent-set (range-set (singleton-range 1) (open-range 1 10)))
         (check-equal? actual expected-equivalent-set))))
 
+
   (test-case "range set sequences"
     (define ranges (range-set (closed-range 2 4) (closed-range 6 8) (closed-range 10 12)))
     (define expected (list (closed-range 2 4) (closed-range 6 8) (closed-range 10 12)))
     (check-equal? (sequence->list ranges) expected))
+  
 
   (test-case "sequence->range-set"
     (define ranges (list (closed-range 2 4) (closed-range 6 8) (closed-range 10 12)))
     (define expected (range-set (closed-range 2 4) (closed-range 6 8) (closed-range 10 12)))
     (check-equal? (sequence->range-set ranges #:comparator real<=>) expected))
 
+
+  (test-case (name-string in-range-set)
+    (define expected (list (closed-range 2 4) (closed-range 6 8) (closed-range 10 12)))
+
+    (test-case "immutable range sets"
+      (define ranges (range-set (closed-range 2 4) (closed-range 6 8) (closed-range 10 12)))
+      (check-equal? (sequence->list (in-range-set ranges)) expected))
+    
+    (test-case "mutable range sets"
+      (define ranges
+        (make-mutable-range-set
+         (list (closed-range 2 4) (closed-range 6 8) (closed-range 10 12)) #:comparator real<=>))
+      (check-equal? (sequence->list (in-range-set ranges)) expected)))
+  
+
+  (test-case (name-string for/range-set)
+    (define expected (range-set (closed-range 2 4) (closed-range 6 8) (closed-range 10 12)))
+    (define actual
+      (for/range-set #:comparator real<=>
+        ([lower (in-list (list 2 6 10))]
+         [upper (in-list (list 4 8 12))])
+        (closed-range lower upper)))
+    (check-equal? actual expected))
+  
+
+  (test-case (name-string for*/range-set)
+    (define range-lists
+      (list (list (closed-range 2 4) (closed-range 6 8) (closed-range 10 12))
+            (list (closed-range 20 40) (closed-range 60 80) (closed-range 100 120))
+            (list (closed-range 200 400) (closed-range 600 800) (closed-range 1000 1200))))
+    (define expected
+      (range-set
+       (closed-range 2 4)
+       (closed-range 6 8)
+       (closed-range 10 12)
+       (closed-range 20 40)
+       (closed-range 60 80)
+       (closed-range 100 120)
+       (closed-range 200 400)
+       (closed-range 600 800)
+       (closed-range 1000 1200)))
+    (define actual
+      (for*/range-set #:comparator real<=>
+        ([range-list (in-list range-lists)]
+         [r (in-list range-list)])
+        r))
+    (check-equal? actual expected))
+  
+
   (test-case "into-range-set"
     (define ranges (list (closed-range 2 4) (closed-range 6 8) (closed-range 10 12)))
     (define expected (range-set (closed-range 2 4) (closed-range 6 8) (closed-range 10 12)))
-    (check-equal? (transduce ranges #:into (into-range-set real<=>)) expected)))
+    (check-equal? (transduce ranges #:into (into-range-set real<=>)) expected))
 
-
-;@----------------------------------------------------------------------------------------------------
-;; Queries
-
-
-(define (range-set-binary-search ranges value)
-  #false)
-
-
-(define (range-set-size ranges)
-  (sorted-map-size (range-set-endpoints ranges)))
-
-
-(define/guard (range-set-get-nearest-range ranges cut)
-  (define endpoints (range-set-endpoints ranges))
-  (guard-match (present (entry lower-endpoint upper-endpoint))
-    (sorted-map-entry-at-most endpoints cut)
-    else
-    absent)
-  (present
-   (range-from-cuts lower-endpoint upper-endpoint #:comparator (range-set-comparator ranges))))
-
-
-(define/guard (range-set-contains? ranges value)
-  (match (range-set-get-nearest-range ranges (middle-cut value))
-    [(== absent) #false]
-    [(present nearest-range) (range-contains? nearest-range value)]))
-
-
-(define/guard (range-set-encloses? ranges other-range)
-  (match (range-set-get-nearest-range ranges (range-lower-cut other-range))
-    [(== absent) #false]
-    [(present nearest-range) (range-encloses? nearest-range other-range)]))
-
-
-(define (range-set-encloses-all? ranges other-ranges)
-  (for/and ([range other-ranges])
-    (range-set-encloses? ranges range)))
-
-
-(define/guard (range-subset ranges subset-range)
-  (define cut-comparator (cut<=> (range-comparator subset-range)))
-  (define lower-subset-cut (range-lower-cut subset-range))
-  (define upper-subset-cut (range-upper-cut subset-range))
-  (define subset-endpoint-range
-    (closed-range lower-subset-cut upper-subset-cut #:comparator cut-comparator))
-
-  (define endpoints-submap (sorted-submap (range-set-endpoints ranges) subset-endpoint-range))
-
-  (define endpoints-submap-with-left-end-corrected
-    (guarded-block
-     (guard-match (present (entry leftmost-range-lower-cut leftmost-range-upper-cut))
-       (sorted-map-entry-at-most (range-set-endpoints ranges) lower-subset-cut)
-       else
-       endpoints-submap)
-     (guard (compare-infix cut-comparator leftmost-range-upper-cut > lower-subset-cut) else
-       endpoints-submap)
-     (define corrected-lower-range
-       (range-from-cuts lower-subset-cut leftmost-range-upper-cut #:comparator cut-comparator))
-     (guard (empty-range? corrected-lower-range) then
-       endpoints-submap)
-     (sorted-map-put endpoints-submap lower-subset-cut leftmost-range-upper-cut)))
-
-  (define endpoints-submap-with-right-end-corrected
-    (guarded-block
-     (guard-match (present (entry rightmost-range-lower-cut rightmost-range-upper-cut))
-       (sorted-map-greatest-entry endpoints-submap-with-left-end-corrected)
-       else
-       endpoints-submap-with-left-end-corrected)
-     (define corrected-upper-cut
-       (comparator-min cut-comparator rightmost-range-upper-cut upper-subset-cut))
-     (define corrected-rightmost-range
-       (range-from-cuts rightmost-range-lower-cut corrected-upper-cut #:comparator cut-comparator))
-     (guard (empty-range? corrected-rightmost-range) then
-       (sorted-map-remove endpoints-submap-with-left-end-corrected rightmost-range-lower-cut))
-     (sorted-map-put
-      endpoints-submap-with-left-end-corrected rightmost-range-lower-cut corrected-upper-cut)))
-
-  (constructor:range-set endpoints-submap-with-right-end-corrected (range-set-comparator ranges)))
-
-
-(module+ test
 
   (test-case "range-set-size"
     (define ranges (range-set (closed-range 2 4) (closed-range 6 8) (closed-range 10 12)))
     (check-equal? (range-set-size ranges) 3))
+
 
   (test-case "range-set-contains?"
     (define ranges (range-set (singleton-range 1) (closed-range 4 7) (greater-than-range 10)))
@@ -443,6 +223,7 @@
     (check-false (range-set-contains? ranges 10))
     (check-true (range-set-contains? ranges 11))
     (check-true (range-set-contains? ranges 12)))
+
 
   (test-case (name-string range-set-encloses?)
     (define ranges (range-set (singleton-range 1) (closed-range 4 7) (greater-than-range 10)))
@@ -464,6 +245,7 @@
     (check-false (range-set-encloses? ranges (closed-range 1 7)))
     (check-false (range-set-encloses? ranges (at-least-range 4))))
 
+
   (test-case (name-string range-set-encloses-all?)
     (define ranges (range-set (singleton-range 1) (closed-range 4 7) (greater-than-range 10)))
     (check-true (range-set-encloses-all? ranges ranges))
@@ -475,6 +257,7 @@
     (check-false (range-set-encloses-all? ranges (list (closed-range 0 1))))
     (check-false (range-set-encloses-all? ranges (list (closed-range 1 2))))
     (check-false (range-set-encloses-all? ranges (list (singleton-range 1) (singleton-range 2)))))
+
 
   (test-case (name-string range-subset)
     (define ranges (range-set (singleton-range 1) (closed-range 4 7) (greater-than-range 10)))
@@ -508,4 +291,306 @@
     (test-case "intersecting subset selecting upper ranges only"
       (define subset-range (greater-than-range 5))
       (define expected (range-set (open-closed-range 5 7) (greater-than-range 10)))
-      (check-equal? (range-subset ranges subset-range) expected))))
+      (check-equal? (range-subset ranges subset-range) expected)))
+
+
+  (test-case (name-string range-set-add)
+
+    (test-case "empty case"
+      (define ranges (range-set #:comparator real<=>))
+
+      (test-case "inserting bounded range"
+        (define actual (range-set-add ranges (closed-range 4 8)))
+        (define expected (range-set (closed-range 4 8)))
+        (check-equal? actual expected))
+
+      (test-case "inserting unbounded range"
+        (define actual (range-set-add ranges (unbounded-range)))
+        (define expected (range-set (unbounded-range)))
+        (check-equal? actual expected))
+
+      (test-case "inserting bounded-below range"
+        (define actual (range-set-add ranges (greater-than-range 6)))
+        (define expected (range-set (greater-than-range 6)))
+        (check-equal? actual expected))
+
+      (test-case "inserting bounded-above range"
+        (define actual (range-set-add ranges (less-than-range 5)))
+        (define expected (range-set (less-than-range 5)))
+        (check-equal? actual expected)))
+
+
+    (test-case "singleton case"
+      (define ranges (range-set (closed-open-range 5 10)))
+
+      (test-case "insert range before"
+        (define actual (range-set-add ranges (closed-open-range 2 4)))
+        (define expected (range-set (closed-open-range 2 4) (closed-open-range 5 10)))
+        (check-equal? actual expected))
+
+      (test-case "insert adjacent range before"
+        (define actual (range-set-add ranges (closed-open-range 2 5)))
+        (define expected (range-set (closed-open-range 2 10)))
+        (check-equal? actual expected))
+
+      (test-case "insert overlapping range before"
+        (define actual (range-set-add ranges (closed-open-range 2 8)))
+        (define expected (range-set (closed-open-range 2 10)))
+        (check-equal? actual expected))
+
+      (test-case "insert enclosing range before"
+        (define actual (range-set-add ranges (closed-open-range 2 10)))
+        (define expected (range-set (closed-open-range 2 10)))
+        (check-equal? actual expected))
+
+      (test-case "insert range after"
+        (define actual (range-set-add ranges (closed-open-range 15 20)))
+        (define expected (range-set (closed-open-range 5 10) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert adjacent range after"
+        (define actual (range-set-add ranges (closed-open-range 10 20)))
+        (define expected (range-set (closed-open-range 5 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert overlapping range after"
+        (define actual (range-set-add ranges (closed-open-range 8 20)))
+        (define expected (range-set (closed-open-range 5 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert enclosing range after"
+        (define actual (range-set-add ranges (closed-open-range 5 20)))
+        (define expected (range-set (closed-open-range 5 20)))
+        (check-equal? actual expected)))
+
+    (test-case "two range case"
+      (define ranges (range-set (closed-open-range 5 10) (closed-open-range 15 20)))
+
+      (test-case "insert range before"
+        (define actual (range-set-add ranges (closed-open-range 2 4)))
+        (define expected
+          (range-set (closed-open-range 2 4) (closed-open-range 5 10) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert adjacent range before"
+        (define actual (range-set-add ranges (closed-open-range 2 5)))
+        (define expected (range-set (closed-open-range 2 10) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert overlapping range before"
+        (define actual (range-set-add ranges (closed-open-range 2 8)))
+        (define expected (range-set (closed-open-range 2 10) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert enclosing range before"
+        (define actual (range-set-add ranges (closed-open-range 2 10)))
+        (define expected (range-set (closed-open-range 2 10) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert range after"
+        (define actual (range-set-add ranges (closed-open-range 22 25)))
+        (define expected
+          (range-set (closed-open-range 5 10) (closed-open-range 15 20) (closed-open-range 22 25)))
+        (check-equal? actual expected))
+
+      (test-case "insert adjacent range after"
+        (define actual (range-set-add ranges (closed-open-range 20 25)))
+        (define expected
+          (range-set (closed-open-range 5 10) (closed-open-range 15 25)))
+        (check-equal? actual expected))
+
+      (test-case "insert overlapping range after"
+        (define actual (range-set-add ranges (closed-open-range 18 25)))
+        (define expected
+          (range-set (closed-open-range 5 10) (closed-open-range 15 25)))
+        (check-equal? actual expected))
+
+      (test-case "insert enclosing range after"
+        (define actual (range-set-add ranges (closed-open-range 15 25)))
+        (define expected
+          (range-set (closed-open-range 5 10) (closed-open-range 15 25)))
+        (check-equal? actual expected))
+
+      (test-case "insert range between"
+        (define actual (range-set-add ranges (closed-open-range 12 14)))
+        (define expected
+          (range-set (closed-open-range 5 10) (closed-open-range 12 14) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert left-adjacent range between"
+        (define actual (range-set-add ranges (closed-open-range 10 14)))
+        (define expected (range-set (closed-open-range 5 14) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert right-adjacent range between"
+        (define actual (range-set-add ranges (closed-open-range 12 15)))
+        (define expected (range-set (closed-open-range 5 10) (closed-open-range 12 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert left-overlapping range between"
+        (define actual (range-set-add ranges (closed-open-range 8 14)))
+        (define expected (range-set (closed-open-range 5 14) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert right-overlapping range between"
+        (define actual (range-set-add ranges (closed-open-range 12 18)))
+        (define expected (range-set (closed-open-range 5 10) (closed-open-range 12 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert left-enclosing range between"
+        (define actual (range-set-add ranges (closed-open-range 5 14)))
+        (define expected (range-set (closed-open-range 5 14) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "insert right-enclosing range between"
+        (define actual (range-set-add ranges (closed-open-range 12 20)))
+        (define expected (range-set (closed-open-range 5 10) (closed-open-range 12 20)))
+        (check-equal? actual expected))))
+
+  (test-case (name-string range-set-remove)
+
+    (test-case "empty case"
+      (define ranges (range-set #:comparator real<=>))
+      (check-equal? (range-set-remove ranges (closed-range 5 10)) ranges)
+      (check-equal? (range-set-remove ranges (open-range 5 10)) ranges)
+      (check-equal? (range-set-remove ranges (closed-open-range 5 10)) ranges)
+      (check-equal? (range-set-remove ranges (open-closed-range 5 10)) ranges)
+      (check-equal? (range-set-remove ranges (greater-than-range 5)) ranges)
+      (check-equal? (range-set-remove ranges (at-least-range 10)) ranges)
+      (check-equal? (range-set-remove ranges (less-than-range 5)) ranges)
+      (check-equal? (range-set-remove ranges (at-most-range 5)) ranges)
+      (check-equal? (range-set-remove ranges (unbounded-range)) ranges))
+
+    (test-case "singleton case"
+      (define ranges (range-set (closed-open-range 5 10)))
+
+      (test-case "remove range before"
+        (check-equal? (range-set-remove ranges (closed-range 2 3)) ranges))
+
+      (test-case "remove adjacent range before"
+        (check-equal? (range-set-remove ranges (closed-open-range 2 5)) ranges))
+
+      (test-case "remove overlapping range before"
+        (define actual (range-set-remove ranges (closed-range 2 7)))
+        (define expected (range-set (open-range 7 10)))
+        (check-equal? actual expected))
+
+      (test-case "remove enclosing range before"
+        (define actual (range-set-remove ranges (closed-open-range 2 10)))
+        (define expected (range-set #:comparator real<=>))
+        (check-equal? actual expected))
+
+      (test-case "remove range after"
+        (check-equal? (range-set-remove ranges (closed-range 12 14)) ranges))
+
+      (test-case "remove adjacent range after"
+        (check-equal? (range-set-remove ranges (closed-range 10 14)) ranges))
+
+      (test-case "remove overlapping range after"
+        (define actual (range-set-remove ranges (closed-range 7 12)))
+        (define expected (range-set (closed-open-range 5 7)))
+        (check-equal? actual expected))
+
+      (test-case "remove enclosing range after"
+        (define actual (range-set-remove ranges (closed-range 5 12)))
+        (define expected (range-set #:comparator real<=>))
+        (check-equal? actual expected))
+
+      (test-case "remove enclosed range"
+        (define actual (range-set-remove ranges (closed-range 7 9)))
+        (define expected (range-set (closed-open-range 5 7) (open-range 9 10)))
+        (check-equal? actual expected)))
+
+    (test-case "two-range case"
+      (define ranges (range-set (closed-open-range 5 10) (closed-open-range 15 20)))
+
+      (test-case "remove range before"
+        (check-equal? (range-set-remove ranges (closed-range 2 3)) ranges))
+
+      (test-case "remove adjacent range before"
+        (check-equal? (range-set-remove ranges (open-range 2 5)) ranges))
+
+      (test-case "remove overlapping range before"
+        (define actual (range-set-remove ranges (closed-range 2 7)))
+        (define expected (range-set (open-range 7 10) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "remove enclosing range before"
+        (define actual (range-set-remove ranges (closed-open-range 2 10)))
+        (define expected (range-set (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "remove left-enclosed range"
+        (define actual (range-set-remove ranges (closed-range 7 8)))
+        (define expected
+          (range-set (closed-open-range 5 7) (open-range 8 10) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "remove range after"
+        (check-equal? (range-set-remove ranges (closed-range 25 28)) ranges))
+
+      (test-case "remove adjacent range after"
+        (check-equal? (range-set-remove ranges (closed-range 20 28)) ranges))
+
+      (test-case "remove overlapping range after"
+        (define actual (range-set-remove ranges (closed-range 18 28)))
+        (define expected (range-set (closed-open-range 5 10) (closed-open-range 15 18)))
+        (check-equal? actual expected))
+      
+      (test-case "remove enclosing range after"
+        (define actual (range-set-remove ranges (closed-range 15 28)))
+        (define expected (range-set (closed-open-range 5 10)))
+        (check-equal? actual expected))
+
+      (test-case "remove right-enclosed range"
+        (define actual (range-set-remove ranges (open-range 17 18)))
+        (define expected
+          (range-set (closed-open-range 5 10) (closed-range 15 17) (closed-open-range 18 20)))
+        (check-equal? actual expected))
+
+      (test-case "remove range between"
+        (check-equal? (range-set-remove ranges (closed-range 12 14)) ranges))
+
+      (test-case "remove left-adjacent range between"
+        (check-equal? (range-set-remove ranges (closed-range 10 14)) ranges))
+
+      (test-case "remove right-adjacent range between"
+        (check-equal? (range-set-remove ranges (closed-open-range 12 15)) ranges))
+
+      (test-case "remove left and right-adjacent range between"
+        (check-equal? (range-set-remove ranges (closed-open-range 10 15)) ranges))
+
+      (test-case "remove left-overlapping range between"
+        (define actual (range-set-remove ranges (closed-range 8 14)))
+        (define expected (range-set (closed-open-range 5 8) (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "remove right-overlapping range between"
+        (define actual (range-set-remove ranges (closed-range 12 17)))
+        (define expected (range-set (closed-open-range 5 10) (open-range 17 20)))
+        (check-equal? actual expected))
+
+      (test-case "remove left and right-overlapping range between"
+        (define actual (range-set-remove ranges (closed-range 8 17)))
+        (define expected (range-set (closed-open-range 5 8) (open-range 17 20)))
+        (check-equal? actual expected))
+
+      (test-case "remove left-enclosing range between"
+        (define actual (range-set-remove ranges (closed-range 5 14)))
+        (define expected (range-set (closed-open-range 15 20)))
+        (check-equal? actual expected))
+
+      (test-case "remove right-enclosing range between"
+        (define actual (range-set-remove ranges (closed-open-range 12 20)))
+        (define expected (range-set (closed-open-range 5 10)))
+        (check-equal? actual expected))
+
+      (test-case "remove left and right-enclosing range between"
+        (define actual (range-set-remove ranges (closed-open-range 5 20)))
+        (define expected (range-set #:comparator real<=>))
+        (check-equal? actual expected))
+
+      (test-case "remove span enclosing range"
+        (define actual (range-set-remove ranges (closed-range 2 25)))
+        (define expected (range-set #:comparator real<=>))
+        (check-equal? actual expected)))))

--- a/collection/range-set.scrbl
+++ b/collection/range-set.scrbl
@@ -29,28 +29,46 @@
 @defmodule[rebellion/collection/range-set]
 
 
-A @deftech{range set} is a sorted set of nonempty, disconnected @tech{ranges}. All ranges in the same
-range set must use the same @tech{comparator}. Range sets are @tech/reference{sequences}, and when
-used as a sequence the set's ranges are iterated in ascending order.
+A @deftech{range set} is a sorted @tech{collection} of nonempty, disconnected @tech{ranges}. All
+ranges in the same range set must use the same @tech{comparator}. Two immutable range sets are
+@racket[equal?] if they contain the same ranges. Two mutable sorted maps are @racket[equal?] if they
+will @emph{always} contain the same ranges, meaning that they share the same mutable state. This is
+not necessarily the same as being @racket[eq?], as some range sets may be views of others.
+
+All range sets are @tech/reference{sequences}. When iterated, a range set traverses its ranges in
+ascending order as defined by the comparator shared by those ranges. To traverse a range set in
+descending order, use @racket[in-range-set] with @racket[#:descending?] set to true.
 
 
 @defproc[(range-set? [v any/c]) boolean?]{
- A predicate for @tech{range sets}.}
+ A predicate for @tech{range sets}. Includes mutable, immutable, and @tech{unmodifiable} range sets.}
+
+
+@defproc[(immutable-range-set? [v any/c]) boolean?]{
+ A predicate for immutable @tech{range sets}. Implies @racket[range-set?].}
+
+
+@defproc[(mutable-range-set? [v any/c]) boolean?]{
+ A predicate for mutable @tech{range sets}. Implies @racket[range-set?].}
+
+
+@section{Constructing Range Sets}
 
 
 @defproc*[([(range-set
              [range nonempty-range?] ...
              [#:comparator comparator comparator?])
-            range-set?]
+            immutable-range-set?]
            [(range-set
              [first-range nonempty-range?]
              [range nonempty-range?] ...
              [#:comparator comparator comparator? (range-comparator first-range)])
-            range-set?])]{
- Constructs a @tech{range set} containing the given @racket[range]s. If at least one @racket[range] is
- provided, @racket[comparator] may be omitted and defaults to the comparator of the first range.
- Overlapping ranges are disallowed, but adjacent ranges are accepted and are merged together. All
- ranges must use @racket[comparator] as their endpoint comparators or a contract exception is raised.
+            immutable-range-set?])]{
+ Constructs an immutable @tech{range set} containing the given @racket[range]s. If at least one
+ @racket[range] is provided, @racket[comparator] may be omitted and defaults to the comparator of the
+ first range. Overlapping ranges are disallowed, but adjacent ranges are accepted and are merged
+ together. All ranges must use @racket[comparator] as their endpoint comparators or a contract
+ exception is raised.
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -60,16 +78,72 @@ used as a sequence the set's ranges are iterated in ascending order.
    (range-set (closed-open-range 2 5) #:comparator real<=>))}
 
 
-@defproc[(empty-range-set? [v any/c]) boolean?]{
- A predicate for empty @tech{range sets}. Implies @racket[range-set?].}
+@defproc[(sequence->range-set
+          [ranges (sequence/c nonempty-range?)]
+          [#:comparator comparator comparator?])
+         immutable-range-set?]{
+ Constructs an immutable @tech{range set} from the given @racket[ranges] (which must use
+ @racket[comparator].) As in the @racket[range-set] consturctor, overlapping ranges are disallowed.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (sequence->range-set
+    (list (closed-range 1 3) (closed-range 10 12) (closed-range 5 6))
+    #:comparator real<=>))}
 
 
-@defthing[empty-range-set empty-range-set?]{
- The empty @tech{range set}, which contains no ranges.}
+@defform[(for/range-set #:comparator comparator (for-clause ...) body-or-break ... body)]{
+ Like @racket[for], but collects the iterated ranges into an immutable @tech{range set}.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (for/range-set #:comparator real<=> ([char (in-string "abcxyz")])
+     (define codepoint (char->integer char))
+     (closed-open-range codepoint (add1 codepoint))))}
 
 
-@defproc[(nonempty-range-set? [v any/c]) boolean?]{
- A predicate for nonempty @tech{range sets}. Implies @racket[range-set?].}
+@defform[(for*/range-set #:comparator comparator (for-clause ...) body-or-break ... body)]{
+ Like @racket[for*], but collects the iterated ranges into an immutable @tech{range set}.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (for*/range-set #:comparator real<=>
+     ([str (in-list (list "abc" "tuv" "xyz" "qrs"))]
+      [char (in-string str)])
+     (define codepoint (char->integer char))
+     (closed-open-range codepoint (add1 codepoint))))}
+
+
+@defproc[(into-range-set [comparator comparator?]) (reducer/c nonempty-range? immutable-range-set?)]{
+ Constructs a @tech{reducer} that reduces a sequence of nonempty ranges (which must use
+ @racket[comparator]) into a @tech{range set}. As in the @racket[range-set] constructor, overlapping
+ ranges are disallowed.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (transduce (list (closed-range 1 3) (closed-range 10 12) (closed-range 5 6))
+              #:into (into-range-set real<=>)))}
+
+
+@section{Iterating Range Sets}
+
+
+@defproc[(in-range-set [range-set range-set?] [#:descending? descending? boolean? #false])
+         (sequence/c nonempty-range?)]{
+ Returns a @tech/reference{sequence} iterating through the ranges in @racket[range-set] in ascending
+ order. Note that @tech{range sets} are already sequences, but this form may yield better performance
+ when used directly within a @racket[for] clause.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (eval:no-prompt
+    (define ranges (range-set (closed-range 1 3) (closed-range 10 12) (closed-range 5 6))))
+
+   (for ([r (in-range-set ranges)])
+     (displayln r))
+
+   (for ([r (in-range-set ranges #:descending? #true)])
+     (displayln r)))}
 
 
 @section{Querying Range Sets}
@@ -87,8 +161,12 @@ used as a sequence the set's ranges are iterated in ascending order.
  Returns the comparator that @racket[ranges] uses to compare elements to its contained ranges.}
 
 
-@defproc[(range-set-contains? [ranges range-set?] [value any/c]) boolean?]{
- Determines if any range in @racket[ranges] contains @racket[value].
+@defproc[(range-set-empty? [ranges range-set?]) boolean?]{
+ Returns true if @racket[ranges] is empty, returns false otherwise.}
+
+
+@defproc[(range-set-contains? [ranges range-set?] [element any/c]) boolean?]{
+ Determines if any range in @racket[ranges] contains @racket[element].
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -97,6 +175,20 @@ used as a sequence the set's ranges are iterated in ascending order.
    (range-set-contains? ranges 2)
    (range-set-contains? ranges 7)
    (range-set-contains? ranges 10))}
+
+
+@defproc[(range-set-contains-all? [ranges range-set?] [elements (sequence/c any/c)]) boolean?]{
+ Determines if @racket[ranges] contains every value in @racket[vs]. If @racket[elements] is empty,
+ returns true.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (eval:no-prompt
+    (define ranges (range-set (closed-range 2 5) (closed-range 9 10))))
+
+   (range-set-contains-all? ranges (list 2 3 4 5 9 10))
+   (range-set-contains-all? ranges (list 4 7))
+   (range-set-contains-all? ranges (list)))}
 
 
 @defproc[(range-set-encloses? [ranges range-set?] [other-range range?]) boolean?]{
@@ -112,7 +204,8 @@ used as a sequence the set's ranges are iterated in ascending order.
 
 
 @defproc[(range-set-encloses-all? [ranges range-set?] [other-ranges (sequence/c range?)]) boolean?]{
- Determines if @racket[ranges] encloses every range in @racket[other-ranges].
+ Determines if @racket[ranges] encloses every range in @racket[other-ranges]. If @racket[other-ranges]
+ is empty, returns true.
 
  @(examples
    #:eval (make-evaluator) #:once
@@ -120,8 +213,65 @@ used as a sequence the set's ranges are iterated in ascending order.
                             (range-set (closed-range 3 4) (closed-range 8 9))))}
 
 
-@defproc[(range-subset [range-set range-set?] [subset-range range?]) range-set?]{
- Returns a range set containing the ranges in @racket[range-set] that are enclosed by
+@defproc[(range-set-intersects? [ranges range-set?] [other-range range?]) boolean?]{
+ Determines if any range in @racket[ranges] intersects with @racket[other-range].
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (eval:no-prompt
+    (define ranges (range-set (closed-range 2 5) (closed-range 9 10))))
+
+   (range-set-intersects? ranges (closed-range 4 8))
+   (range-set-intersects? ranges (closed-range 6 8)))}
+
+
+@defproc[(range-set-range-containing [ranges range-set?]
+                                     [element any/c]
+                                     [failure-result failure-result/c (λ () (raise ...))])
+         any/c]{
+ Returns the range in @racket[ranges] that contains @racket[element]. If no range contains
+ @racket[element], then @racket[failure-result] determines the result: if it's a procedure it's called
+ with no arguments to produce the result, if it's not a procedure it's returned directly.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (eval:no-prompt
+    (define ranges (range-set (closed-range 2 5) (closed-range 9 10))))
+   
+   (range-set-range-containing ranges 4)
+   (range-set-range-containing ranges 9)
+   (eval:error (range-set-range-containing ranges 7))
+   (range-set-range-containing ranges 7 #false))}
+
+
+@defproc[(range-set-range-containing-or-absent [ranges range-set?] [element any/c])
+         (option/c range?)]{
+ Returns the range in @racket[ranges] that contains @racket[element], wrapped in a @racket[present]
+ option. If no range contains @racket[element], then @racket[absent] is returned.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (eval:no-prompt
+    (define ranges (range-set (closed-range 2 5) (closed-range 9 10))))
+   
+   (range-set-range-containing-or-absent ranges 4)
+   (range-set-range-containing-or-absent ranges 9)
+   (range-set-range-containing-or-absent ranges 7))}
+
+
+@defproc[(range-set-span [ranges range-set?] [empty-result failure-result/c (λ () (raise ...))])
+         any/c]
+
+
+@defproc[(range-set-span-or-absent [ranges range-set?]) (option/c range?)]
+
+
+@section{Range Set Views}
+
+
+@defproc[(range-subset [ranges range-set?] [subset-range range?]) range-set?]{
+
+ Returns a range set containing the ranges in @racket[ranges] that are enclosed by
  @racket[subset-range].
 
  @(examples
@@ -131,57 +281,47 @@ used as a sequence the set's ranges are iterated in ascending order.
    (range-subset ranges (less-than-range 4)))}
 
 
-@section{Range Set Iterations and Comprehensions}
+@section{Modifying Range Sets}
 
 
-@defproc[(in-range-set [range-set range-set?]) (sequence/c nonempty-range?)]{
- Returns a @tech/reference{sequence} iterating through the ranges in @racket[range-set] in ascending
- order. Note that @tech{range sets} are already sequences, but this form may yield better performance
- when used directly within a @racket[for] clause.}
+@defproc[(range-set-add [ranges immutable-range-set?] [new-range range?]) immutable-range-set?]{
 
-
-@defproc[(into-range-set [comparator comparator?]) (reducer/c nonempty-range? range-set?)]{
- Constructs a @tech{reducer} that reduces a sequence of nonempty ranges (which must use
- @racket[comparator]) into a @tech{range set}. As in the @racket[range-set] constructor, overlapping
- ranges are disallowed.
+ Functionally adds @racket[new-range] to @racket[ranges] by returning a new range set containing
+ all of the ranges in @racket[ranges] and @racket[new-range]. Overlapping and adjacent ranges are
+ coalesced. The input range set is not modified.
 
  @(examples
    #:eval (make-evaluator) #:once
-   (transduce (list (closed-range 1 3) (closed-range 10 12) (closed-range 5 6))
-              #:into (into-range-set real<=>)))}
+   (eval:no-prompt
+    (define ranges (range-set (closed-range 2 5) (closed-range 7 10))))
+   (range-set-add ranges (closed-range 0 3))
+   (range-set-add ranges (closed-range 6 12))
+   (range-set-add ranges (closed-range 4 8)))}
 
 
-@defproc[(sequence->range-set
-          [ranges (sequence/c nonempty-range?)]
-          [#:comparator comparator comparator?])
-         range-set?]{
- Constructs a @tech{range set} from the given @racket[ranges] (which must use @racket[comparator].) As
- in the @racket[range-set] consturctor, overlapping ranges are disallowed.
-
- @(examples
-   #:eval (make-evaluator) #:once
-   (sequence->range-set
-    (list (closed-range 1 3) (closed-range 10 12) (closed-range 5 6))
-    #:comparator real<=>))}
+@defproc[(range-set-add! [ranges mutable-range-set?] [new-range range?]) void?]
 
 
-@defform[(for/range-set #:comparator comparator (for-clause ...) body-or-break ... body)]{
- Like @racket[for], but collects the iterated ranges into a @tech{range set}.
-
- @(examples
-   #:eval (make-evaluator) #:once
-   (for/range-set #:comparator real<=> ([char (in-string "abcxyz")])
-     (define codepoint (char->integer char))
-     (closed-open-range codepoint (add1 codepoint))))}
+@defproc[(range-set-add-all [ranges immutable-range-set?] [new-ranges (sequence/c range?)])
+         immutable-range-set?]
 
 
-@defform[(for*/range-set #:comparator comparator (for-clause ...) body-or-break ... body)]{
- Like @racket[for*], but collects the iterated ranges into a @tech{range set}.
+@defproc[(range-set-add-all! [ranges mutable-range-set?] [new-ranges (sequence/c range?)]) void?]
 
- @(examples
-   #:eval (make-evaluator) #:once
-   (for*/range-set #:comparator real<=>
-     ([str (in-list (list "abc" "tuv" "xyz" "qrs"))]
-      [char (in-string str)])
-     (define codepoint (char->integer char))
-     (closed-open-range codepoint (add1 codepoint))))}
+
+@defproc[(range-set-remove [ranges immutable-range-set?] [range-to-remove range?])
+         immutable-range-set?]
+
+
+@defproc[(range-set-remove! [ranges mutable-range-set?] [range-to-remove range?]) void?]
+
+
+@defproc[(range-set-remove-all [ranges immutable-range-set?] [ranges-to-remove (sequence/c range?)])
+         immutable-range-set?]
+
+
+@defproc[(range-set-remove-all! [ranges mutable-range-set?] [ranges-to-remove (sequence/c range?)])
+         void?]
+
+
+@defproc[(range-set-clear! [ranges mutable-range-set?]) void?]

--- a/private/cut.rkt
+++ b/private/cut.rkt
@@ -14,7 +14,8 @@
   [bottom-cut cut?]
   [intermediate-cut? predicate/c]
   [intermediate-cut-value (-> intermediate-cut? any/c)]
-  [cut<=> (-> comparator? (comparator/c cut?))]))
+  [cut<=> (-> comparator? (comparator/c cut?))]
+  [cut-flip-side (-> cut? cut?)]))
 
 
 (require racket/match
@@ -100,3 +101,10 @@
   (guard (middle-cut? right) then
     greater)
   equivalent)
+
+
+(define (cut-flip-side cut)
+  (match cut
+    [(upper-cut value) (lower-cut value)]
+    [(lower-cut value) (upper-cut value)]
+    [_ cut]))

--- a/private/todo.rkt
+++ b/private/todo.rkt
@@ -1,0 +1,20 @@
+#lang racket/base
+
+
+(provide TODO)
+
+
+(require (for-syntax racket/base
+                     syntax/parse))
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define-syntax (TODO stx)
+  (syntax-parse stx
+    #:track-literals
+    #:literals (TODO)
+    [TODO
+     #:with original stx
+     #'(raise-syntax-error #false "not yet implemented" #'original)]))

--- a/private/vector-merge-adjacent.rkt
+++ b/private/vector-merge-adjacent.rkt
@@ -1,0 +1,89 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [vector-merge-adjacent
+   (-> vector? (-> any/c any/c boolean?) (-> any/c any/c any/c) (and/c vector? immutable?))]))
+
+
+(require rebellion/collection/vector/builder
+         rebellion/private/guarded-block)
+
+
+(module+ test
+  (require (submod "..")
+           rackunit
+           rebellion/private/static-name))
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+;; Returns a new (immutable) vector that is like vec, except adjacent elements are merged with
+;; merge-function when should-merge? returns true.
+;;
+;; Examples:
+;;
+;; > (vector-merge-adjacent (vector 1 2 3 "hello" 4 5 "world" 6) both-numbers? +)
+;; (vector 6 "hello" 9 "world" 6)
+;;
+(define/guard (vector-merge-adjacent vec should-merge? merge-function)
+  (define count (vector-length vec))
+  (guard (< count 2) then
+    (vector->immutable-vector vec))
+  (for/fold ([builder (make-vector-builder #:expected-size count)]
+             [element (vector-ref vec 0)]
+             #:result (build-vector (vector-builder-add builder element)))
+            ([next-element (in-vector vec 1)])
+    (if (should-merge? element next-element)
+        (values builder (merge-function element next-element))
+        (values (vector-builder-add builder element) next-element))))
+
+
+(module+ test
+  (test-case (name-string vector-merge-adjacent)
+
+    (define (both-numbers? left right)
+      (and (number? left) (number? right)))
+
+    (define (fail-immediately left right)
+      (raise 'should-not-be-called))
+
+    (test-case "empty vectors are returned uninspected"
+      (define actual (vector-merge-adjacent (vector-immutable) fail-immediately fail-immediately))
+      (check-equal? actual (vector-immutable)))
+
+    (test-case "single-element vectors are returned uninspected"
+      (define actual (vector-merge-adjacent (vector-immutable 1) fail-immediately fail-immediately))
+      (check-equal? actual (vector-immutable 1)))
+
+    (test-case "can merge all elements"
+      (define actual (vector-merge-adjacent (vector-immutable 1 2 3 4 5) (λ (a b) #true) +))
+      (check-equal? actual (vector-immutable 15)))
+
+    (test-case "can merge no elements"
+      (define actual
+        (vector-merge-adjacent (vector-immutable 1 2 3 4 5) (λ (a b) #false) fail-immediately))
+      (check-equal? actual (vector-immutable 1 2 3 4 5)))
+
+    (test-case "can merge elements at start"
+      (define actual (vector-merge-adjacent (vector-immutable 1 2 3 'a 'b 'c) both-numbers? +))
+      (check-equal? actual (vector-immutable 6 'a 'b 'c)))
+
+    (test-case "can merge elements at end"
+      (define actual (vector-merge-adjacent (vector-immutable 'a 'b 'c 4 5 6) both-numbers? +))
+      (check-equal? actual (vector-immutable 'a 'b 'c 15)))
+
+    (test-case "can merge elements in middle"
+      (define actual
+        (vector-merge-adjacent (vector-immutable 'a 'b 'c 4 5 6 'd 'e 'f) both-numbers? +))
+      (check-equal? actual (vector-immutable 'a 'b 'c 15 'd 'e 'f)))
+
+    (test-case "can merge elements in middle multiple times"
+      (define actual
+        (vector-merge-adjacent (vector-immutable 1 2 3 "hello" 4 5 "world" 6) both-numbers? +))
+      (check-equal? actual (vector-immutable 6 "hello" 9 "world" 6)))))


### PR DESCRIPTION
This pull request reimplements range sets in terms of sorted maps, which allows for persistent range sets and mutable range sets. The latter is not fully implemented, but it's good enough for use in jackfirth/resyntax#164 which is what I need this for.