### PR TITLE
Add `splicing-between` transducer

### DIFF
--- a/streaming/transducer.rkt
+++ b/streaming/transducer.rkt
@@ -10,6 +10,7 @@
          rebellion/streaming/transducer/private/enumerating
          rebellion/streaming/transducer/private/reducer
          rebellion/streaming/transducer/private/sorting
+         rebellion/streaming/transducer/private/splicing-between
          rebellion/streaming/transducer/private/taking-duplicates
          rebellion/streaming/transducer/private/taking-local-maxima
          rebellion/streaming/transducer/private/taking-maxima
@@ -26,6 +27,7 @@
                        rebellion/streaming/transducer/private/enumerating
                        rebellion/streaming/transducer/private/reducer
                        rebellion/streaming/transducer/private/sorting
+                       rebellion/streaming/transducer/private/splicing-between
                        rebellion/streaming/transducer/private/taking-duplicates
                        rebellion/streaming/transducer/private/taking-local-maxima
                        rebellion/streaming/transducer/private/taking-maxima

--- a/streaming/transducer.scrbl
+++ b/streaming/transducer.scrbl
@@ -6,6 +6,7 @@
                      racket/contract/region
                      racket/math
                      racket/sequence
+                     racket/random
                      racket/set
                      rebellion/base/comparator
                      rebellion/base/immutable-string
@@ -25,6 +26,7 @@
    (make-module-sharing-evaluator-factory
     #:public (list 'racket/contract/region
                    'racket/math
+                   'racket/random
                    'racket/set
                    'rebellion/base/comparator
                    'rebellion/base/immutable-string
@@ -397,6 +399,41 @@ early, before the input sequence is fully consumed.
  @(examples
    #:eval (make-evaluator) #:once
    (transduce "BEHOLD" (adding-between #\space) #:into into-string))}
+
+
+@defproc[(splicing-between [seperator-seq (sequence/c any/c)]) transducer?]{
+ Constructs a @tech{transducer} that inserts each element of @racket[separator-seq] between elements
+ of the transduced sequence. If the input sequence does not contain at least two elements, nothing is
+ inserted.
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (transduce "BEHOLD" (splicing-between "   ") #:into into-string))
+
+ Beware that if @racket[separator-seq] is inserted into the input sequence multiple times, it is
+ @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{initiate}d each time it's inserted. This
+ can have unexpected behavior with sequences that have side effects, sequences that are
+ nondeterministic, and sequences that observe concurrently-mutated state. This behavior can be
+ suppressed by converting the sequence to a
+ @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{stream} using @racket[sequence->stream].
+
+ @(examples
+   #:eval (make-evaluator) #:once
+   (eval:no-prompt
+    (struct shoes-or-hat ()
+      (code:comment "This sequence randomly picks between a pair of shoes or a single hat")
+      #:property prop:sequence
+      (λ (this)
+        (random-ref (list (list 'shoe 'shoe)
+                          (list 'hat))))))
+
+   (transduce (list 1 2 3 4 5 6)
+              (splicing-between (shoes-or-hat))
+              #:into into-list)
+   
+   (transduce (list 1 2 3 4 5 6)
+              (splicing-between (sequence->stream (shoes-or-hat)))
+              #:into into-list))}
 
 
 @section{Rearranging Elements with Transducers}

--- a/streaming/transducer/private/splicing-between-test.rkt
+++ b/streaming/transducer/private/splicing-between-test.rkt
@@ -1,0 +1,103 @@
+#lang racket/base
+
+
+(module+ test
+  (require rackunit
+           rebellion/collection/list
+           rebellion/private/static-name
+           rebellion/streaming/reducer
+           rebellion/streaming/transducer
+           rebellion/streaming/transducer/testing))
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(module+ test
+  (test-case (name-string splicing-between)
+
+    (test-case "should do nothing for empty sequences"
+      (define actual-events
+        (transduce "" (observing-transduction-events (splicing-between ", ")) #:into into-list))
+      
+      (define expected-events
+        (list start-event
+              half-close-event
+              finish-event))
+      (check-equal? actual-events expected-events))
+
+    (test-case "should leave singleton sequences unchanged"
+      (define actual-events
+        (transduce "x" (observing-transduction-events (splicing-between ", ")) #:into into-list))
+      
+      (define expected-events
+        (list start-event
+              (consume-event #\x)
+              half-close-event
+              (half-closed-emit-event #\x)
+              finish-event))
+      (check-equal? actual-events expected-events))
+    
+    (test-case "should add an element in the middle of two-element sequences"
+      (define actual-events
+        (transduce "xy" (observing-transduction-events (splicing-between ", ")) #:into into-list))
+      
+      (define expected-events
+        (list start-event
+              (consume-event #\x)
+              (consume-event #\y)
+              (emit-event #\x)
+              (emit-event #\,)
+              (emit-event #\space)
+              half-close-event
+              (half-closed-emit-event #\y)
+              finish-event))
+      (check-equal? actual-events expected-events))
+
+    (test-case "should add an element between each element of a many-element sequence"
+      (define actual-events
+        (transduce "wxyz"
+                   (observing-transduction-events (splicing-between ", "))
+                   #:into into-list))
+      
+      (define expected-events
+        (list start-event
+              (consume-event #\w)
+              (consume-event #\x)
+              (emit-event #\w)
+              (emit-event #\,)
+              (emit-event #\space)
+              (consume-event #\y)
+              (emit-event #\x)
+              (emit-event #\,)
+              (emit-event #\space)
+              (consume-event #\z)
+              (emit-event #\y)
+              (emit-event #\,)
+              (emit-event #\space)
+              half-close-event
+              (half-closed-emit-event #\z)
+              finish-event))
+      (check-equal? actual-events expected-events))
+
+    (struct intiation-counting-sequence (base-sequence [count #:mutable])
+      #:property prop:sequence
+      (λ (this)
+        (set-intiation-counting-sequence-count! this (add1 (intiation-counting-sequence-count this)))
+        (intiation-counting-sequence-base-sequence this)))
+
+    (define (sequence-count-initations seq)
+      (intiation-counting-sequence seq 0))
+
+    (test-case "should initiate the separator sequence each time it's inserted"
+      (define separator-seq (sequence-count-initations ", "))
+      (transduce "abcde" (splicing-between separator-seq) #:into into-string)
+      (check-equal? (intiation-counting-sequence-count separator-seq) 4))
+
+    (test-case "should support infinite separator sequences via lazy iteration"
+      (define actual
+        (transduce (list 'foo 'bar)
+                   (splicing-between (in-naturals))
+                   (taking 5)
+                   #:into into-list))
+      (check-equal? actual (list 'foo 0 1 2 3)))))

--- a/streaming/transducer/private/splicing-between.rkt
+++ b/streaming/transducer/private/splicing-between.rkt
@@ -1,0 +1,79 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [splicing-between (-> (sequence/c any/c) transducer?)]))
+
+
+(require racket/match
+         racket/sequence
+         rebellion/base/option
+         rebellion/base/variant
+         rebellion/private/static-name
+         rebellion/streaming/transducer/base
+         rebellion/type/record)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define-record-type element-emit-state (previous-element buffered-element))
+(define-record-type in-between-emit-state (splice-element splice-iterator buffered-element))
+
+
+(define (splicing-between seq)
+  (make-transducer
+
+   #:starter (λ () (variant #:consume absent))
+
+   #:consumer
+   (λ (previous-element-opt next)
+     (match previous-element-opt
+       [(present e)
+        (variant #:emit (element-emit-state #:previous-element e #:buffered-element next))]
+       [(== absent) (variant #:consume (present next))]))
+
+   #:emitter
+   (λ (state)
+     (match state
+       [(element-emit-state #:previous-element prev #:buffered-element buffered)
+        (define-values (head iterator) (sequence-generate* seq))
+        (define next-state
+          (match head
+            [(list e)
+             (define s
+               (in-between-emit-state
+                #:splice-element e #:splice-iterator iterator #:buffered-element buffered))
+             (variant #:emit s)]
+            [#false (variant #:consume (present buffered))]))
+        (emission next-state prev)]
+       [(in-between-emit-state
+         #:splice-element head #:splice-iterator iterator #:buffered-element buffered)
+        (define-values (next-head next-iterator) (iterator))
+        (define next-state
+          (match next-head
+            [(list e)
+             (define s
+               (in-between-emit-state
+                #:splice-element e #:splice-iterator next-iterator #:buffered-element buffered))
+             (variant #:emit s)]
+            [#false (variant #:consume (present buffered))]))
+        (emission next-state head)]))
+
+   #:half-closer
+   (λ (previous-element-opt)
+     (match previous-element-opt
+       [(present e) (variant #:half-closed-emit e)]
+       [(== absent) (variant #:finish #false)]))
+
+   #:half-closed-emitter
+   (λ (last-element)
+     (half-closed-emission (variant #:finish #false) last-element))
+
+   #:finisher void
+
+   #:name (name splicing-between)))


### PR DESCRIPTION
This is a complement to #524 for inserting entire sequences between elements instead of just single elements.