### PR TITLE
Added support for more kinds of `object-name` values

### DIFF
--- a/custom-write.rkt
+++ b/custom-write.rkt
@@ -6,8 +6,9 @@
  (contract-out
   [custom-write-mode/c flat-contract?]
   [custom-write-function/c chaperone-contract?]
+  [object-name/c flat-contract?]
   [make-named-object-custom-write
-   (->* (symbol?) (#:name-getter (-> any/c (or/c symbol? #false)))
+   (->* (symbol?) (#:name-getter (-> any/c (or/c object-name/c #false)))
         custom-write-function/c)]))
 
 ;@------------------------------------------------------------------------------
@@ -16,6 +17,16 @@
 
 (define custom-write-function/c
   (-> any/c output-port? custom-write-mode/c void?))
+
+(define object-name/c (or/c symbol? string? bytes? number? path?))
+
+(define (object-name->string name)
+  (cond
+    [(symbol? name) (symbol->string name)]
+    [(string? name) name]
+    [(bytes? name) (bytes->string/locale name #\�)]
+    [(number? name) (number->string name)]
+    [(path? name) (path->string name)]))
 
 (define (make-named-object-custom-write type-name
                                         #:name-getter [get-name object-name])
@@ -26,6 +37,6 @@
       (define name (get-name this))
       (when name
         (write-string ":")
-        (write-string (symbol->string name)))
+        (write-string (object-name->string name)))
       (write-string ">"))
     (void)))

--- a/custom-write.scrbl
+++ b/custom-write.scrbl
@@ -38,9 +38,16 @@ must satisfy the @racket[custom-write-function/c] contract.
  matching @racket[custom-write-function/c]. See @racket[gen:custom-write] for
  details.}
 
+@defthing[object-name/c flat-contract?
+          #:value (or/c symbol? string? bytes? number? path? #false)]{
+ A @tech/reference{contract} describing expected return values of
+ @racket[object-name]. Note that @racket[object-name] can technically return any
+ kind of value, so more precisely this contract describes the name values that
+ @racket[make-named-object-custom-write] will accept.}
+
 @defproc[(make-named-object-custom-write
           [type-name symbol?]
-          [#:name-getter get-name (-> any/c (or/c symbol? #false)) object-name])
+          [#:name-getter get-name (-> any/c object-name/c) object-name])
          custom-write-function/c]{
  Constructs a @tech{custom write implementation} that prints values as opaque,
  unreadable, named objects, similar to the way functions are printed.


### PR DESCRIPTION
This fixes the issue presented in #526. An `object-name/c` contract has been added and `make-named-object-custom-write` has been modified to accept the new kinds of names.