### PR TITLE
Rename `range-set-intersects?`

### DIFF
--- a/base/range.scrbl
+++ b/base/range.scrbl
@@ -548,10 +548,12 @@ whether the bound is inclusive or exclusive.
 @defproc[(range-intersection [range1 range?] [range2 range?]) range?]{
  Returns the largest range that is @tech{enclose}d by both @racket[range1] and @racket[range2]. The
  ranges must be connected and use the same @tech{comparator} or else a contract error is raised. This
- operation is commutative, associative, and idempotent.
+ operation is commutative, associative, and idempotent. If the two ranges are adjacent, then an empty
+ range is returned.
 
  @(examples
    #:eval (make-evaluator) #:once
    (range-intersection (closed-range 2 8) (open-range 4 16))
    (range-intersection (greater-than-range 4) (less-than-range 6))
-   (range-intersection (open-range 2 8) (at-most-range 5)))}
+   (range-intersection (open-range 2 8) (at-most-range 5))
+   (range-intersection (less-than-range 4) (singleton-range 4)))}

--- a/collection/private/endpoint-map-range-set.rkt
+++ b/collection/private/endpoint-map-range-set.rkt
@@ -79,8 +79,8 @@
    (define (range-set-encloses? this range)
      (endpoint-map-encloses? (this-endpoints this) (this-comparator this) range))
 
-   (define (range-set-intersects? this range)
-     (endpoint-map-intersects? (this-endpoints this) (this-comparator this) range))
+   (define (range-set-overlaps? this range)
+     (endpoint-map-overlaps? (this-endpoints this) (this-comparator this) range))
 
    (define (range-set-range-containing-or-absent this value)
      (endpoint-map-range-containing-or-absent (this-endpoints this) (this-comparator this) value))
@@ -281,8 +281,8 @@
    (define (range-set-encloses? this range)
      (endpoint-map-encloses? (this-endpoints this) (this-comparator this) range))
 
-   (define (range-set-intersects? this range)
-     (endpoint-map-intersects? (this-endpoints this) (this-comparator this) range))
+   (define (range-set-overlaps? this range)
+     (endpoint-map-overlaps? (this-endpoints this) (this-comparator this) range))
 
    (define (range-set-range-containing-or-absent this value)
      (endpoint-map-range-containing-or-absent (this-endpoints this) (this-comparator this) value))
@@ -474,7 +474,7 @@
      (and (range-encloses? (this-subrange this) range)
           (generic-range-set-encloses? (this-delegate-range-set this) range)))
 
-   (define (range-set-intersects? this range)
+   (define (range-set-overlaps? this range)
      TODO)
 
    (define/guard (range-set-range-containing-or-absent this value)
@@ -563,7 +563,7 @@
     [(present nearest-range) (range-encloses? nearest-range range)]))
 
 
-(define/guard (endpoint-map-intersects? endpoints comparator range)
+(define/guard (endpoint-map-overlaps? endpoints comparator range)
   (define lower-cut (range-lower-cut range))
   (define upper-cut (range-upper-cut range))
   (guard-match (present (entry _ upper)) (sorted-map-entry-at-most endpoints upper-cut) else

--- a/collection/private/range-set-interface.rkt
+++ b/collection/private/range-set-interface.rkt
@@ -17,7 +17,7 @@
   [range-set-contains-all? (-> range-set? (sequence/c any/c) boolean?)]
   [range-set-encloses? (-> range-set? range? boolean?)]
   [range-set-encloses-all? (-> range-set? (sequence/c range?) boolean?)]
-  [range-set-intersects? (-> range-set? range? boolean?)]
+  [range-set-overlaps? (-> range-set? range? boolean?)]
   [range-set-range-containing (->* (range-set? any/c) (failure-result/c) any)]
   [range-set-range-containing-or-absent (-> range-set? any/c (option/c range?))]
   [range-set-span (->* (range-set?) (failure-result/c) any)]
@@ -85,7 +85,7 @@
   (range-set-contains-all? range-set values)
   (range-set-encloses? range-set range)
   (range-set-encloses-all? range-set ranges)
-  (range-set-intersects? range-set range)
+  (range-set-overlaps? range-set range)
   (range-set-range-containing range-set value [failure-result])
   (range-set-range-containing-or-absent range-set value)
   (range-set-span range-set [failure-result])

--- a/collection/range-set.rkt
+++ b/collection/range-set.rkt
@@ -25,7 +25,7 @@
   range-set-contains-all?
   range-set-encloses?
   range-set-encloses-all?
-  range-set-intersects?
+  range-set-overlaps?
   range-set-range-containing
   range-set-range-containing-or-absent
   range-set-span
@@ -40,6 +40,10 @@
   range-set-remove-all!
   range-set-clear!
   range-subset)
+
+ ;; Deprecated legacy alias of range-set-overlaps?
+ (rename-out [range-set-overlaps? range-set-intersects?])
+
  (contract-out
   [empty-range-set? predicate/c]
   [nonempty-range-set? predicate/c]))
@@ -57,7 +61,7 @@
 
 
 ;@----------------------------------------------------------------------------------------------------
-;; Data definition
+
 
 (define (empty-range-set? v)
   (and (range-set? v) (range-set-empty? v)))

--- a/collection/range-set.scrbl
+++ b/collection/range-set.scrbl
@@ -233,16 +233,16 @@ descending order, use @racket[in-range-set] with @racket[#:descending?] set to t
                             (range-set (closed-range 3 4) (closed-range 8 9))))}
 
 
-@defproc[(range-set-intersects? [ranges range-set?] [other-range range?]) boolean?]{
- Determines if any range in @racket[ranges] intersects with @racket[other-range].
+@defproc[(range-set-overlaps? [ranges range-set?] [other-range range?]) boolean?]{
+ Determines if any range in @racket[ranges] overlaps with @racket[other-range].
 
  @(examples
    #:eval (make-evaluator) #:once
    (eval:no-prompt
     (define ranges (range-set (closed-range 2 5) (closed-range 9 10))))
 
-   (range-set-intersects? ranges (closed-range 4 8))
-   (range-set-intersects? ranges (closed-range 6 8)))}
+   (range-set-overlaps? ranges (closed-range 4 8))
+   (range-set-overlaps? ranges (closed-range 6 8)))}
 
 
 @defproc[(range-set-range-containing [ranges range-set?]


### PR DESCRIPTION
It actually checks if any range in the set *overlaps* with the given range, which is when two ranges have a *nonempty* intersection. Updated docs and renamed it to `range-set-overlaps?` to clarify this. The old name is kept around as a deprecated legacy alias.