### PR TITLE
Fix a transducer composition bug.

### DIFF
--- a/streaming/transducer/composition-test.rkt
+++ b/streaming/transducer/composition-test.rkt
@@ -66,11 +66,33 @@
        #:half-closed-emitter (λ (_) em)
        #:finisher void))
 
+    (define finishing
+      (make-transducer
+       #:starter (λ () (variant #:finish #false))
+       #:consumer (λ (state element) (error "impossible"))
+       #:emitter impossible
+       #:half-closer impossible
+       #:half-closed-emitter impossible
+       #:finisher void))
+
     (test-case "half closed upstream emisisons makes downstream half closed"
       (define piped
         (observing-transduction-events
          (transducer-pipe (half-closed-emitting #\a)
                           (taking 3))))
+      (define inputs (in-naturals))
+      (define expected
+        (list start-event
+              (half-closed-emit-event #\a)
+              (half-closed-emit-event #\a)
+              (half-closed-emit-event #\a)
+              finish-event))
+      (check-equal? (transduce inputs piped #:into into-list) expected))
+
+    (test-case "finished upstream makes downstream half closed"
+      (define piped
+        (observing-transduction-events
+         (transducer-pipe finishing (emitting #\a) (taking 3))))
       (define inputs (in-naturals))
       (define expected
         (list start-event

--- a/streaming/transducer/composition.rkt
+++ b/streaming/transducer/composition.rkt
@@ -58,9 +58,9 @@
   (define upstream (pipe-state-upstream-state v))
   (define downstream (pipe-state-downstream-state v))
   (and (variant-tagged-as? downstream '#:emit)
-       (or (not (variant? upstream))
-           (and (not (variant-tagged-as? upstream '#:half-closed-emit))
-                (not (variant-tagged-as? upstream '#:finish))))))
+       upstream
+       (not (variant-tagged-as? upstream '#:half-closed-emit))
+       (not (variant-tagged-as? upstream '#:finish))))
 
 (define/guard (half-closed-emit-pipe-state? v)
   (guard (pipe-state? v) #:else
@@ -69,8 +69,8 @@
   (define downstream (pipe-state-downstream-state v))
   (or (variant-tagged-as? downstream '#:half-closed-emit)
       (and (variant-tagged-as? downstream '#:emit)
-           (variant? upstream)
-           (or (variant-tagged-as? upstream '#:half-closed-emit)
+           (or (not upstream)
+               (variant-tagged-as? upstream '#:half-closed-emit)
                (variant-tagged-as? upstream '#:finish)))))
 
 (define (finish-pipe-state? v)


### PR DESCRIPTION
This stream pipeline currently errors:

```scheme
(transduce (in-range 0 10) (sorting) (mapping values) #:into (into-list))
```

This is due to a bug in the logic for composing two transducers together. When the upstream transducer is finished, and the downstream transducer emits a value, that emission should be changed to a half-closed emission. The current logic doesn't do that and results in a contract error. This commit fixes the issue and adds a test.